### PR TITLE
Feature/lfa 980 short description text box other screen

### DIFF
--- a/src/controllers/other/reason.other.controller.ts
+++ b/src/controllers/other/reason.other.controller.ts
@@ -62,9 +62,16 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     }
   } else {
     const changingDetails = req.chSession.data[keys.CHANGING_DETAILS];
+    let reasonInput = req.body.otherReason;
+    if (!reasonInput || reasonInput.trim().length === 0) {
+      reasonInput = "Not provided";
+    }
+
     await reasonService.updateReason(
       req.chSession,
-      {reason_information: removeNonPrintableChars(req.body.otherInformation)});
+      {
+        reason: reasonInput,
+        reason_information: removeNonPrintableChars(req.body.otherInformation)});
 
     if (changingDetails) {
       return res.redirect(pageURLs.EXTENSIONS_CHECK_YOUR_ANSWERS);

--- a/src/test/controllers/other/reason.other.controller.spec.unit.ts
+++ b/src/test/controllers/other/reason.other.controller.spec.unit.ts
@@ -93,7 +93,7 @@ describe("reason other validation tests", () => {
     expect(mockUpdateReasonService).not.toHaveBeenCalled();
   });
 
-  it("should receive no error message requesting more information when text input is supplied", async () => {
+  it("should receive no error message requesting more information when text input is supplied and reason not supplied", async () => {
     mockCacheService.prototype.constructor.mockImplementationOnce(() => session);
     const res = await request(app)
       .post(pageURLs.EXTENSIONS_REASON_OTHER)
@@ -106,6 +106,7 @@ describe("reason other validation tests", () => {
     expect(res.status).toEqual(302);
     expect(res.text).not.toContain(NO_INFORMATION_INPUT);
     expect(mockUpdateReasonService).toHaveBeenCalledWith(session, {
+      reason: "Not provided",
       reason_information: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     });
   });
@@ -123,7 +124,66 @@ describe("reason other validation tests", () => {
     expect(res.status).toEqual(302);
     expect(res.text).not.toContain(NO_INFORMATION_INPUT);
     expect(mockUpdateReasonService).toHaveBeenCalledWith(session, {
+      reason: "Not provided",
       reason_information: "Lorem ipsum dolor sit amet,  consectetur adipiscing elit."
     });
   });
+
+  it("should receive no error message when reason is empty", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(() => session);
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_REASON_OTHER)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        otherReason: "",
+        otherInformation: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      });
+    expect(res.header.location).toEqual(pageURLs.EXTENSIONS_EVIDENCE_OPTION);
+    expect(res.status).toEqual(302);
+    expect(res.text).not.toContain(NO_INFORMATION_INPUT);
+    expect(mockUpdateReasonService).toHaveBeenCalledWith(session, {
+      reason: "Not provided",
+      reason_information: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    });
+  });
+
+  it("should receive no error message when reason is blank", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(() => session);
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_REASON_OTHER)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        otherReason: "    ",
+        otherInformation: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      });
+    expect(res.header.location).toEqual(pageURLs.EXTENSIONS_EVIDENCE_OPTION);
+    expect(res.status).toEqual(302);
+    expect(res.text).not.toContain(NO_INFORMATION_INPUT);
+    expect(mockUpdateReasonService).toHaveBeenCalledWith(session, {
+      reason: "Not provided",
+      reason_information: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    });
+  });
+
+  it("should receive no error message when both the reason and text input are supplied and see the reason in the updte call", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(() => session);
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_REASON_OTHER)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        otherReason: "This is a test",
+        otherInformation: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      });
+    expect(res.header.location).toEqual(pageURLs.EXTENSIONS_EVIDENCE_OPTION);
+    expect(res.status).toEqual(302);
+    expect(res.text).not.toContain(NO_INFORMATION_INPUT);
+    expect(mockUpdateReasonService).toHaveBeenCalledWith(session, {
+      reason: "This is a test",
+      reason_information: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    });
+  });
+
 });

--- a/views/other/reason-other.html
+++ b/views/other/reason-other.html
@@ -40,6 +40,21 @@
         {% endif %}
 
         <h1 class="govuk-heading-xl">Provide more information to support your extension</h1>
+
+        {{ govukInput({
+          id: "other-reason",
+          name: "otherReason",
+          value: title,
+          classes: "",
+          attributes: {
+            "data-event-id": "other-reason-input"
+          },
+            label: {
+            text: "Short title for the reason (optional)"
+          }
+        }) }}
+
+
         {{ govukTextarea({
           name: "otherInformation",
           id: "other-information",

--- a/views/other/reason-other.html
+++ b/views/other/reason-other.html
@@ -39,7 +39,8 @@
           {% set inputErrorMessage = false %}
         {% endif %}
 
-        <h1 class="govuk-heading-xl">Provide more information to support your extension</h1>
+        <h1 class="govuk-heading-xl">Provide more information to support your application</h1>
+        <p class="govuk-body-l">Anything you tell us to support your application will be kept confidential.</p>
 
         {{ govukInput({
           id: "other-reason",
@@ -62,7 +63,7 @@
           errorMessage: inputErrorMessage,
           rows: "8",
           label: {
-            text: "Anything you tell us to support your extension will be kept confidential.",
+            text: "Detailed description of the reason",
             isPageHeading: true,
             classes: "govuk-heading-large"
           }


### PR DESCRIPTION
Added new field to other reason page, it is optional so reads "Not provided" if left empty of blank. 
Wording on other information screen altered as shown on ticket LFA-980.
Unit tests to demo this.