### PR TITLE
Updates to start screen

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -31,12 +31,6 @@
       </h1>
       <p class="govuk-body-l">Use this service to apply for more time to file your annual accounts with Companies House.</p>
       <p>It may take up to 30 minutes to complete this application.</p>
-      <a id="start-now" href="/extensions/company-number" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-event-id="start-now-button">Start now</a>
-      <h2 class="govuk-heading-m">Before you start</h2>
-      <p>
-        You should
-        <a href="https://www.gov.uk/government/publications/life-of-a-company-annual-requirements/life-of-a-company-part-1-accounts#how-to-request-extra-time-to-file-your-companys-accounts" target="_blank">read the guidance on extending your filing deadline</a>
-      </p>
       <h3 class="govuk-heading-s">You'll need:</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>the company number</li>
@@ -44,11 +38,22 @@
         <li>information about your extension reasons</li>
         <li>any documents that support your application (optional)</li>
       </ul>
+      <a id="start-now" href="/extensions/company-number" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-event-id="start-now-button">Start now</a>
+      <h2 class="govuk-heading-m">Before you start</h2>
+      <p>
+        You can apply for more time to file if something has happened that is out of your control and you cannot file your company accounts on time.
+      </p>
+      <p>
+        You must send your application to us before your normal filing deadline. It should include a full explanation of why you need the extension.
+      </p>
+      <p>
+        We will not issue you a late filing penalty if your application is approved and you file your accounts before the extended deadline.
+      </p>
     </div>
     <div class="govuk-grid-column-one-third">
       <aside class="app-related-items" role="complementary">
         <h2 class="govuk-heading-m" id="subsection-title">
-          Related content
+          Subsection
         </h2>
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="govuk-list govuk-body-s">


### PR DESCRIPTION
Updated start screen to match the updated prototype: 

The "Related content" header is now called "Sub section"

"You'll need" moved to before start button.

The link to guidance has been removed. 

Guidance info has been added.