### PR TITLE
Error handling on date pages

### DIFF
--- a/src/controllers/accounts/accounts.date.controller.ts
+++ b/src/controllers/accounts/accounts.date.controller.ts
@@ -5,6 +5,7 @@ import * as errorMessages from "../../model/error.messages";
 import {createGovUkErrorData, GovUkErrorData} from "../../model/govuk.error.data";
 import {ValidationError} from "../../model/validation.error";
 import {EXTENSIONS_ACCOUNTS_INFORMATION} from "../../model/page.urls";
+import * as dateValidationUtils from "../../global/date.validation.utils";
 import * as keys from "../../session/keys";
 import * as pageURLs from "../../model/page.urls";
 import * as reasonService from "../../services/reason.service";
@@ -105,17 +106,17 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
         }
         switch ((valErr.param)) {
           case ACCOUNTING_ISSUE_DAY_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             dateDayErrorFlag = true;
             break;
           case ACCOUNTING_ISSUE_MONTH_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             dateMonthErrorFlag = true;
             break;
           case ACCOUNTING_ISSUE_YEAR_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             dateYearErrorFlag = true;
             break;
@@ -151,16 +152,6 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   } else {
     return res.redirect(EXTENSIONS_ACCOUNTS_INFORMATION);
   }
-};
-
-const updateDateErrorMessage = (errorMessage: string, dataToAppend: string, isFirstError: boolean): string => {
-  let updatedErrorMessage: string = errorMessage;
-  if (!isFirstError) {
-    updatedErrorMessage += " and a " + dataToAppend;
-  } else {
-    updatedErrorMessage += dataToAppend;
-  }
-  return updatedErrorMessage;
 };
 
 export default [extractFullDate, ...validators, route];

--- a/src/controllers/accounts/accounts.date.controller.ts
+++ b/src/controllers/accounts/accounts.date.controller.ts
@@ -1,9 +1,8 @@
 import {NextFunction, Request, Response} from "express";
 import {check, validationResult} from "express-validator/check";
 import * as moment from "moment";
-import * as ErrorMessages from "../../model/error.messages";
+import * as errorMessages from "../../model/error.messages";
 import {createGovUkErrorData, GovUkErrorData} from "../../model/govuk.error.data";
-import * as TemplatePaths from "../../model/template.paths";
 import {ValidationError} from "../../model/validation.error";
 import {EXTENSIONS_ACCOUNTS_INFORMATION} from "../../model/page.urls";
 import * as keys from "../../session/keys";
@@ -37,19 +36,21 @@ const extractFullDate = async (req: Request, res: Response, next: NextFunction):
 };
 
 const validators = [
-  check(ACCOUNTING_ISSUE_DAY_FIELD).escape().not().isEmpty().withMessage(ErrorMessages.DAY_MISSING),
-  check(ACCOUNTING_ISSUE_MONTH_FIELD).escape().not().isEmpty().withMessage(ErrorMessages.MONTH_MISSING),
-  check(ACCOUNTING_ISSUE_YEAR_FIELD).escape().not().isEmpty().withMessage(ErrorMessages.YEAR_MISSING),
+  check(ACCOUNTING_ISSUE_DAY_FIELD).escape().not().isEmpty().withMessage("day"),
+  check(ACCOUNTING_ISSUE_MONTH_FIELD).escape().not().isEmpty().withMessage("month"),
+  check(ACCOUNTING_ISSUE_YEAR_FIELD).escape().not().isEmpty().withMessage("year"),
 
-  // Check date is a valid date and not in the future
+  // Check date is present, valid and not in the future
   check(ACCOUNTING_ISSUE_FULL_DATE_FIELD).escape().custom((fullDate, {req}) => {
     if (allDateFieldsPresent(req)) {
       if (!moment(fullDate, "YYYY-MM-DD", true).isValid()) {
-        throw Error(ErrorMessages.DATE_INVALID);
+        throw Error(errorMessages.DATE_INVALID);
       }
       if (moment().isBefore(fullDate)) {
-        throw Error(ErrorMessages.DATE_FUTURE);
+        throw Error(errorMessages.DATE_FUTURE);
       }
+    } else if (fullDate === "00-00-00") {
+        throw Error(errorMessages.DATE_MISSING);
     }
     return true;
   }),
@@ -80,7 +81,6 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
 };
 
 const route = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-
   const errors = validationResult(req);
 
   const errorListData: GovUkErrorData[] = [];
@@ -93,34 +93,46 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   const year: string = req.body[ACCOUNTING_ISSUE_YEAR_FIELD];
 
   if (!errors.isEmpty()) {
+    let dateErrorMessage: string = errorMessages.BASE_DATE_ERROR_MESSAGE;
+    let href: string = "";
+    let isFirstError: boolean = true;
+
     // Get the first error only for each field
     errors.array({ onlyFirstError: true })
       .forEach((valErr: ValidationError) => {
-
-        const href: string = (
-          valErr.param === ACCOUNTING_ISSUE_FULL_DATE_FIELD) ? ACCOUNTING_ISSUE_DAY_FIELD : valErr.param;
-        const govUkErrorData: GovUkErrorData = createGovUkErrorData(
-          valErr.msg, "#" + href, true, "");
+        if (!href) {
+          href = valErr.param;
+        }
         switch ((valErr.param)) {
           case ACCOUNTING_ISSUE_DAY_FIELD:
+            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            isFirstError = false;
             dateDayErrorFlag = true;
             break;
           case ACCOUNTING_ISSUE_MONTH_FIELD:
+            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            isFirstError = false;
             dateMonthErrorFlag = true;
             break;
           case ACCOUNTING_ISSUE_YEAR_FIELD:
+            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            isFirstError = false;
             dateYearErrorFlag = true;
             break;
           case ACCOUNTING_ISSUE_FULL_DATE_FIELD:
+            dateErrorMessage = valErr.msg;
             dateDayErrorFlag = true;
             dateMonthErrorFlag = true;
             dateYearErrorFlag = true;
         }
 
-        errorListData.push(govUkErrorData);
       });
 
-    return res.render(TemplatePaths.REASON_ACCOUNTING_ISSUE, {
+    const govUkErrorData: GovUkErrorData = createGovUkErrorData(
+      dateErrorMessage, "#" + href, true, "");
+    errorListData.push(govUkErrorData);
+
+    return res.render(templatePaths.REASON_ACCOUNTING_ISSUE, {
       accountsDay: day,
       accountsMonth: month,
       accountsYear: year,
@@ -139,6 +151,16 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   } else {
     return res.redirect(EXTENSIONS_ACCOUNTS_INFORMATION);
   }
+};
+
+const updateDateErrorMessage = (errorMessage: string, dataToAppend: string, isFirstError: boolean): string => {
+  let updatedErrorMessage: string = errorMessage;
+  if (!isFirstError) {
+    updatedErrorMessage += " and a " + dataToAppend;
+  } else {
+    updatedErrorMessage += dataToAppend;
+  }
+  return updatedErrorMessage;
 };
 
 export default [extractFullDate, ...validators, route];

--- a/src/controllers/illness/illness.end.date.controller.ts
+++ b/src/controllers/illness/illness.end.date.controller.ts
@@ -4,11 +4,12 @@ import * as moment from "moment";
 import * as errorMessages from "../../model/error.messages";
 import {createGovUkErrorData, GovUkErrorData} from "../../model/govuk.error.data";
 import {ValidationError} from "../../model/validation.error";
-import * as templatePaths from "../../model/template.paths";
-import * as pageURLs from "../../model/page.urls";
+import * as dateValidationUtils from "../../global/date.validation.utils";
 import * as keys from "../../session/keys";
-import * as sessionService from "../../services/session.service";
+import * as pageURLs from "../../model/page.urls";
 import * as reasonService from "../../services/reason.service";
+import * as sessionService from "../../services/session.service";
+import * as templatePaths from "../../model/template.paths";
 import { ReasonWeb } from "model/reason/extension.reason.web";
 import {formatDateForDisplay, formatDateForReason} from "../../client/date.formatter";
 
@@ -114,17 +115,17 @@ export const processForm = [extractFullDate, ...validators,
         }
         switch ((valErr.param)) {
           case ILLNESS_END_DAY_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             endDateDayErrorFlag = true;
             break;
           case ILLNESS_END_MONTH_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             endDateMonthErrorFlag = true;
             break;
           case ILLNESS_END_YEAR_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             endDateYearErrorFlag = true;
             break;
@@ -162,16 +163,6 @@ export const processForm = [extractFullDate, ...validators,
     return res.redirect(pageURLs.EXTENSIONS_ILLNESS_INFORMATION);
   }
 }];
-
-const updateDateErrorMessage = (errorMessage: string, dataToAppend: string, isFirstError: boolean): string => {
-  let updatedErrorMessage: string = errorMessage;
-  if (!isFirstError) {
-    updatedErrorMessage += " and a " + dataToAppend;
-  } else {
-    updatedErrorMessage += dataToAppend;
-  }
-  return updatedErrorMessage;
-};
 
 const getCurrentExtensionReason = async (req: Request): Promise<ReasonWeb> => {
   return await reasonService.getCurrentReason(req.chSession) as ReasonWeb;

--- a/src/controllers/illness/illness.start.date.controller.ts
+++ b/src/controllers/illness/illness.start.date.controller.ts
@@ -6,6 +6,7 @@ import {createGovUkErrorData, GovUkErrorData} from "../../model/govuk.error.data
 import * as templatePaths from "../../model/template.paths";
 import {ValidationError} from "../../model/validation.error";
 import {EXTENSIONS_CONTINUED_ILLNESS} from "../../model/page.urls";
+import * as dateValidationUtils from "../../global/date.validation.utils";
 import * as keys from "../../session/keys";
 import * as pageURLs from "../../model/page.urls";
 import * as reasonService from "../../services/reason.service";
@@ -105,17 +106,17 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
         }
         switch ((valErr.param)) {
           case ILLNESS_START_DAY_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             startDateDayErrorFlag = true;
             break;
           case ILLNESS_START_MONTH_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             startDateMonthErrorFlag = true;
             break;
           case ILLNESS_START_YEAR_FIELD:
-            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            dateErrorMessage = dateValidationUtils.updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
             isFirstError = false;
             startDateYearErrorFlag = true;
             break;
@@ -151,16 +152,6 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   } else {
     return res.redirect(EXTENSIONS_CONTINUED_ILLNESS);
   }
-};
-
-const updateDateErrorMessage = (errorMessage: string, dataToAppend: string, isFirstError: boolean): string => {
-  let updatedErrorMessage: string = errorMessage;
-  if (!isFirstError) {
-    updatedErrorMessage += " and a " + dataToAppend;
-  } else {
-    updatedErrorMessage += dataToAppend;
-  }
-  return updatedErrorMessage;
 };
 
 export default  [extractFullDate, ...validators, route];

--- a/src/controllers/illness/illness.start.date.controller.ts
+++ b/src/controllers/illness/illness.start.date.controller.ts
@@ -36,19 +36,21 @@ const extractFullDate = async (req: Request, res: Response, next: NextFunction):
 };
 
 const validators = [
-  check(ILLNESS_START_DAY_FIELD).escape().not().isEmpty().withMessage(errorMessages.DAY_MISSING),
-  check(ILLNESS_START_MONTH_FIELD).escape().not().isEmpty().withMessage(errorMessages.MONTH_MISSING),
-  check(ILLNESS_START_YEAR_FIELD).escape().not().isEmpty().withMessage(errorMessages.YEAR_MISSING),
+  check(ILLNESS_START_DAY_FIELD).escape().not().isEmpty().withMessage("day"),
+  check(ILLNESS_START_MONTH_FIELD).escape().not().isEmpty().withMessage("month"),
+  check(ILLNESS_START_YEAR_FIELD).escape().not().isEmpty().withMessage("year"),
 
   // Check date is a valid date and not in the future
   check(ILLNESS_START_FULL_DATE_FIELD).escape().custom((fullDate, {req}) => {
     if (allDateFieldsPresent(req)) {
       if (!moment(fullDate, "YYYY-MM-DD", true).isValid()) {
-        throw Error(errorMessages.ILLNESS_START_DATE_INVALID);
+        throw Error(errorMessages.DATE_INVALID);
       }
       if (moment().isBefore(fullDate)) {
         throw Error(errorMessages.ILLNESS_START_DATE_FUTURE);
       }
+    } else if (fullDate === "00-00-00") {
+      throw Error(errorMessages.DATE_MISSING);
     }
     return true;
   }),
@@ -91,30 +93,44 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   const year: string = req.body[ILLNESS_START_YEAR_FIELD];
 
   if (!errors.isEmpty()) {
+    let dateErrorMessage: string = errorMessages.BASE_DATE_ERROR_MESSAGE;
+    let href: string = "";
+    let isFirstError: boolean = true;
+
     // Get the first error only for each field
     errors.array({ onlyFirstError: true })
       .forEach((valErr: ValidationError) => {
-
-        const href: string = (valErr.param === ILLNESS_START_FULL_DATE_FIELD) ? ILLNESS_START_DAY_FIELD : valErr.param;
-        const govUkErrorData: GovUkErrorData = createGovUkErrorData(valErr.msg, "#" + href, true, "");
+        if (!href) {
+          href = valErr.param;
+        }
         switch ((valErr.param)) {
           case ILLNESS_START_DAY_FIELD:
+            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            isFirstError = false;
             startDateDayErrorFlag = true;
             break;
           case ILLNESS_START_MONTH_FIELD:
+            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            isFirstError = false;
             startDateMonthErrorFlag = true;
             break;
           case ILLNESS_START_YEAR_FIELD:
+            dateErrorMessage = updateDateErrorMessage(dateErrorMessage, valErr.msg, isFirstError);
+            isFirstError = false;
             startDateYearErrorFlag = true;
             break;
           case ILLNESS_START_FULL_DATE_FIELD:
+            dateErrorMessage = valErr.msg;
             startDateDayErrorFlag = true;
             startDateMonthErrorFlag = true;
             startDateYearErrorFlag = true;
         }
 
-        errorListData.push(govUkErrorData);
       });
+
+    const govUkErrorData: GovUkErrorData = createGovUkErrorData(
+      dateErrorMessage, "#" + href, true, "");
+    errorListData.push(govUkErrorData);
 
     return res.render(templatePaths.ILLNESS_START_DATE, {
       errorList: errorListData,
@@ -137,4 +153,14 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   }
 };
 
-export default [extractFullDate, ...validators, route];
+const updateDateErrorMessage = (errorMessage: string, dataToAppend: string, isFirstError: boolean): string => {
+  let updatedErrorMessage: string = errorMessage;
+  if (!isFirstError) {
+    updatedErrorMessage += " and a " + dataToAppend;
+  } else {
+    updatedErrorMessage += dataToAppend;
+  }
+  return updatedErrorMessage;
+};
+
+export default  [extractFullDate, ...validators, route];

--- a/src/global/date.validation.utils.ts
+++ b/src/global/date.validation.utils.ts
@@ -1,0 +1,7 @@
+export const updateDateErrorMessage = (errorMessage: string, dataToAppend: string, isFirstError: boolean): string => {
+  let updatedErrorMessage: string = errorMessage;
+  if (!isFirstError) {
+    updatedErrorMessage += " and a";
+  }
+  return updatedErrorMessage + " " + dataToAppend;
+};

--- a/src/model/error.messages.ts
+++ b/src/model/error.messages.ts
@@ -18,7 +18,7 @@ export const NO_INFORMATION_INPUT: string = "You must give us more information";
 export const WHO_WAS_ILL_NOT_SELECTED: string = "You must select a person";
 export const WHO_WAS_ILL_OTHER_NOT_SELECTED: string = "You must tell us the person";
 
-export const BASE_DATE_ERROR_MESSAGE: string = "Enter a ";
+export const BASE_DATE_ERROR_MESSAGE: string = "Enter a";
 
 export const DATE_MISSING: string = "Enter a date";
 export const DATE_INVALID: string = "Enter a real date";

--- a/src/model/error.messages.ts
+++ b/src/model/error.messages.ts
@@ -18,17 +18,14 @@ export const NO_INFORMATION_INPUT: string = "You must give us more information";
 export const WHO_WAS_ILL_NOT_SELECTED: string = "You must select a person";
 export const WHO_WAS_ILL_OTHER_NOT_SELECTED: string = "You must tell us the person";
 
-export const DAY_MISSING: string = "You must enter a day";
-export const MONTH_MISSING: string = "You must enter a month";
-export const YEAR_MISSING: string = "You must enter a year";
+export const BASE_DATE_ERROR_MESSAGE: string = "Enter a ";
 
+export const DATE_MISSING: string = "Enter a date";
 export const DATE_INVALID: string = "Enter a real date";
 export const DATE_FUTURE: string = "Date must be today or in the past";
 
-export const ILLNESS_START_DATE_INVALID: string = "Enter a real start date";
 export const ILLNESS_START_DATE_FUTURE: string = "Start date must be today or in the past";
 
-export const ILLNESS_END_DATE_INVALID: string = "Enter a real end date";
 export const ILLNESS_END_DATE_FUTURE: string = "End date must be today or in the past";
 export const ILLNESS_END_BEFORE_START_DATE: string = "End date must not precede start date";
 

--- a/src/test/controllers/accounts/accounts.date.controller.spec.unit.ts
+++ b/src/test/controllers/accounts/accounts.date.controller.spec.unit.ts
@@ -17,9 +17,13 @@ const mockCacheService = (<unknown>loadSession as jest.Mock<typeof loadSession>)
 const mockUpdateReason = (<unknown>updateReason as jest.Mock<typeof updateReason>);
 const mockGetCurrentReason = (<unknown>reasonService.getCurrentReason as jest.Mock<typeof reasonService.getCurrentReason>);
 
-const DAY_MISSING: string = "You must enter a day";
-const MONTH_MISSING: string = "You must enter a month";
-const YEAR_MISSING: string = "You must enter a year";
+const FULL_DATE_MISSING: string = "Enter a date";
+const DAY_MISSING: string = "Enter a day";
+const DAY_AND_MONTH_MISSING = "Enter a day and a month";
+const DAY_AND_YEAR_MISSING = "Enter a day and a year";
+const MONTH_MISSING: string = "Enter a month";
+const MONTH_AND_YEAR_MISSING: string = "Enter a month and a year";
+const YEAR_MISSING: string = "Enter a year";
 const DATE_INVALID: string = "Enter a real date";
 const DATE_FUTURE: string = "Date must be today or in the past";
 const DATE_TITLE: string = "When did the accounting issue happen?";
@@ -105,15 +109,17 @@ describe("accounting issue date url tests", () => {
 
 describe("accounts date validation tests", () => {
 
-  it("should show 3 errors if accounting issue date day, month and year are missing", async () => {
+  it("should show 1 error if accounting issue date day, month and year are missing", async () => {
     const res = await request(app)
       .post(PageURLs.EXTENSIONS_REASON_ACCOUNTING_ISSUE)
       .set("Accept", "application/json")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"accounts-date-day": "", "accounts-date-month": "", "accounts-date-year": ""});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(DAY_MISSING);
-    expect(res.text).toContain(MONTH_MISSING);
-    expect(res.text).toContain(YEAR_MISSING);
+    expect(res.text).toContain(FULL_DATE_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
@@ -127,6 +133,33 @@ describe("accounts date validation tests", () => {
     expect(res.text).toContain(DAY_MISSING);
     expect(res.text).not.toContain(MONTH_MISSING);
     expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
+  });
+
+  it("should show error if accounting issue date day and month is missing", async () => {
+    const res = await request(app)
+      .post(PageURLs.EXTENSIONS_REASON_ACCOUNTING_ISSUE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"accounts-date-day": "", "accounts-date-month": "", "accounts-date-year": "2016"});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(DAY_AND_MONTH_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
+  });
+
+  it("should show error if accounting issue date day and year is missing", async () => {
+    const res = await request(app)
+      .post(PageURLs.EXTENSIONS_REASON_ACCOUNTING_ISSUE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"accounts-date-day": "", "accounts-date-month": "02", "accounts-date-year": ""});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(DAY_AND_YEAR_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
   it("should show error if accounting issue date month is missing", async () => {
@@ -138,6 +171,19 @@ describe("accounts date validation tests", () => {
     expect(res.status).toEqual(200);
     expect(res.text).not.toContain(DAY_MISSING);
     expect(res.text).toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
+  });
+
+  it("should show error if accounting issue date month and year is missing", async () => {
+    const res = await request(app)
+      .post(PageURLs.EXTENSIONS_REASON_ACCOUNTING_ISSUE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"accounts-date-day": "11", "accounts-date-month": "", "accounts-date-year": ""});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(MONTH_AND_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
     expect(res.text).not.toContain(YEAR_MISSING);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });

--- a/src/test/controllers/illness/illness.end.date.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.end.date.controller.spec.unit.ts
@@ -16,10 +16,14 @@ jest.mock("../../../services/reason.service");
 const mockCacheService = (<unknown>loadSession as jest.Mock<typeof loadSession>);
 const mockGetCurrentReason = (<unknown>reasonService.getCurrentReason as jest.Mock<typeof reasonService.getCurrentReason>);
 
-const ILLNESS_END_DAY_MISSING: string = "You must enter a day";
-const ILLNESS_END_MONTH_MISSING: string = "You must enter a month";
-const ILLNESS_END_YEAR_MISSING: string = "You must enter a year";
-const ILLNESS_END_DATE_INVALID: string = "Enter a real end date";
+const FULL_DATE_MISSING: string = "Enter a date";
+const DAY_MISSING: string = "Enter a day";
+const DAY_AND_MONTH_MISSING = "Enter a day and a month";
+const DAY_AND_YEAR_MISSING = "Enter a day and a year";
+const MONTH_MISSING: string = "Enter a month";
+const MONTH_AND_YEAR_MISSING: string = "Enter a month and a year";
+const YEAR_MISSING: string = "Enter a year";
+const DATE_INVALID: string = "Enter a real date";
 const ILLNESS_END_DATE_FUTURE: string = "End date must be today or in the past";
 const ILLNESS_END_BEFORE_START_DATE: string = "End date must not precede start date";
 
@@ -67,16 +71,18 @@ describe("illness end date url tests", () => {
 
 describe("illness end date validation tests", () => {
 
-  it("should show 3 errors if end date day, month and year are missing", async () => {
+  it("should show 1 error if end date day, month and year are missing", async () => {
     mockCacheService.prototype.constructor.mockImplementationOnce(fullDummySession);
     const res = await request(app)
       .post(pageURLs.EXTENSIONS_ILLNESS_END_DATE)
       .set("Accept", "application/json")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-end-day": "", "illness-end-month": "", "illness-end-year": ""});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_END_DAY_MISSING);
-    expect(res.text).toContain(ILLNESS_END_MONTH_MISSING);
-    expect(res.text).toContain(ILLNESS_END_YEAR_MISSING);
+    expect(res.text).toContain(FULL_DATE_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
   });
 
   it("should show error if end date day is missing", async () => {
@@ -87,9 +93,37 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "", "illness-end-month": "02", "illness-end-year": "2016"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_END_DAY_MISSING);
-    expect(res.text).not.toContain(ILLNESS_END_MONTH_MISSING);
-    expect(res.text).not.toContain(ILLNESS_END_YEAR_MISSING);
+    expect(res.text).toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockGetCurrentReason).toBeCalledTimes(1);
+  });
+
+  it("should show error if end date day and month is missing", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(fullDummySession);
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_ILLNESS_END_DATE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-end-day": "", "illness-end-month": "", "illness-end-year": "2016"});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(DAY_AND_MONTH_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockGetCurrentReason).toBeCalledTimes(1);
+  });
+
+  it("should show error if end date day and year is missing", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(fullDummySession);
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_ILLNESS_END_DATE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-end-day": "", "illness-end-month": "10", "illness-end-year": ""});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(DAY_AND_YEAR_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
 
@@ -101,9 +135,23 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "11", "illness-end-month": "", "illness-end-year": "2016"});
     expect(res.status).toEqual(200);
-    expect(res.text).not.toContain(ILLNESS_END_DAY_MISSING);
-    expect(res.text).toContain(ILLNESS_END_MONTH_MISSING);
-    expect(res.text).not.toContain(ILLNESS_END_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockGetCurrentReason).toBeCalledTimes(1);
+  });
+
+  it("should show error if end date month and year is missing", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(fullDummySession);
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_ILLNESS_END_DATE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-end-day": "11", "illness-end-month": "", "illness-end-year": ""});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(MONTH_AND_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
 
@@ -115,9 +163,9 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "11", "illness-end-month": "11", "illness-end-year": ""});
     expect(res.status).toEqual(200);
-    expect(res.text).not.toContain(ILLNESS_END_DAY_MISSING);
-    expect(res.text).not.toContain(ILLNESS_END_MONTH_MISSING);
-    expect(res.text).toContain(ILLNESS_END_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).toContain(YEAR_MISSING);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
 
@@ -129,7 +177,7 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "32", "illness-end-month": "11", "illness-end-year": "2018"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_END_DATE_INVALID);
+    expect(res.text).toContain(DATE_INVALID);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
 
@@ -141,7 +189,7 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "29", "illness-end-month": "02", "illness-end-year": "2015"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_END_DATE_INVALID);
+    expect(res.text).toContain(DATE_INVALID);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
 
@@ -154,7 +202,7 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "29", "illness-end-month": "02", "illness-end-year": "2016"});
     expect(res.status).toEqual(302);
-    expect(res.text).not.toContain(ILLNESS_END_DATE_INVALID);
+    expect(res.text).not.toContain(DATE_INVALID);
     expect(res.header.location).toEqual(pageUrls.EXTENSIONS_ILLNESS_INFORMATION);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
@@ -167,7 +215,7 @@ describe("illness end date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-end-day": "aa", "illness-end-month": "bb", "illness-end-year": "cc"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_END_DATE_INVALID);
+    expect(res.text).toContain(DATE_INVALID);
     expect(mockGetCurrentReason).toBeCalledTimes(1);
   });
 

--- a/src/test/controllers/illness/illness.start.date.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.start.date.controller.spec.unit.ts
@@ -17,10 +17,14 @@ const mockCacheService = (<unknown>loadSession as jest.Mock<typeof loadSession>)
 const mockUpdateReason = (<unknown>updateReason as jest.Mock<typeof updateReason>);
 const mockGetCurrentReason = (<unknown>reasonService.getCurrentReason as jest.Mock<typeof reasonService.getCurrentReason>);
 
-const ILLNESS_START_DAY_MISSING: string = "You must enter a day";
-const ILLNESS_START_MONTH_MISSING: string = "You must enter a month";
-const ILLNESS_START_YEAR_MISSING: string = "You must enter a year";
-const ILLNESS_START_DATE_INVALID: string = "Enter a real start date";
+const FULL_DATE_MISSING: string = "Enter a date";
+const DAY_MISSING: string = "Enter a day";
+const DAY_AND_MONTH_MISSING = "Enter a day and a month";
+const DAY_AND_YEAR_MISSING = "Enter a day and a year";
+const MONTH_MISSING: string = "Enter a month";
+const MONTH_AND_YEAR_MISSING: string = "Enter a month and a year";
+const YEAR_MISSING: string = "Enter a year";
+const DATE_INVALID: string = "Enter a real date";
 const ILLNESS_START_DATE_FUTURE: string = "Start date must be today or in the past";
 const ILLNESS_START_DATE_TITLE: string = "When did the illness start";
 
@@ -104,15 +108,17 @@ describe("illness start date url tests", () => {
 
 describe("illness start date validation tests", () => {
 
-  it("should show 3 errors if start date day, month and year are missing", async () => {
+  it("should show 1 error if start date day, month and year are missing", async () => {
     const res = await request(app)
       .post(PageURLs.EXTENSIONS_ILLNESS_START_DATE)
       .set("Accept", "application/json")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-start-day": "", "illness-start-month": "", "illness-start-year": ""});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_START_DAY_MISSING);
-    expect(res.text).toContain(ILLNESS_START_MONTH_MISSING);
-    expect(res.text).toContain(ILLNESS_START_YEAR_MISSING);
+    expect(res.text).toContain(FULL_DATE_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
@@ -123,9 +129,36 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "", "illness-start-month": "02", "illness-start-year": "2016"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_START_DAY_MISSING);
-    expect(res.text).not.toContain(ILLNESS_START_MONTH_MISSING);
-    expect(res.text).not.toContain(ILLNESS_START_YEAR_MISSING);
+    expect(res.text).toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
+  });
+
+  it("should show error if start date day and month are missing", async () => {
+    const res = await request(app)
+      .post(PageURLs.EXTENSIONS_ILLNESS_START_DATE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-start-day": "", "illness-start-month": "", "illness-start-year": "2016"});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(DAY_AND_MONTH_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
+  });
+
+  it("should show error if start date day and year are missing", async () => {
+    const res = await request(app)
+      .post(PageURLs.EXTENSIONS_ILLNESS_START_DATE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-start-day": "", "illness-start-month": "10", "illness-start-year": ""});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(DAY_AND_YEAR_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
   it("should show error if start date month is missing", async () => {
@@ -135,9 +168,22 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "11", "illness-start-month": "", "illness-start-year": "2016"});
     expect(res.status).toEqual(200);
-    expect(res.text).not.toContain(ILLNESS_START_DAY_MISSING);
-    expect(res.text).toContain(ILLNESS_START_MONTH_MISSING);
-    expect(res.text).not.toContain(ILLNESS_START_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).toContain(MONTH_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
+    expect(mockUpdateReason).not.toHaveBeenCalled();
+  });
+
+  it("should show error if start date month and year are missing", async () => {
+    const res = await request(app)
+      .post(PageURLs.EXTENSIONS_ILLNESS_START_DATE)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({"illness-start-day": "10", "illness-start-month": "", "illness-start-year": ""});
+    expect(res.status).toEqual(200);
+    expect(res.text).toContain(MONTH_AND_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(YEAR_MISSING);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
@@ -148,9 +194,9 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "11", "illness-start-month": "11", "illness-start-year": ""});
     expect(res.status).toEqual(200);
-    expect(res.text).not.toContain(ILLNESS_START_DAY_MISSING);
-    expect(res.text).not.toContain(ILLNESS_START_MONTH_MISSING);
-    expect(res.text).toContain(ILLNESS_START_YEAR_MISSING);
+    expect(res.text).not.toContain(DAY_MISSING);
+    expect(res.text).not.toContain(MONTH_MISSING);
+    expect(res.text).toContain(YEAR_MISSING);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
@@ -161,7 +207,7 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "31", "illness-start-month": "06", "illness-start-year": "2018"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_START_DATE_INVALID);
+    expect(res.text).toContain(DATE_INVALID);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
@@ -172,7 +218,7 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "29", "illness-start-month": "2", "illness-start-year": "2015"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_START_DATE_INVALID);
+    expect(res.text).toContain(DATE_INVALID);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 
@@ -183,7 +229,7 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "29", "illness-start-month": "2", "illness-start-year": "2016"});
     expect(res.status).toEqual(302);
-    expect(res.text).not.toContain(ILLNESS_START_DATE_INVALID);
+    expect(res.text).not.toContain(DATE_INVALID);
     const dummySession = fullDummySession();
     expect(mockUpdateReason).toHaveBeenCalledWith(dummySession, {
       start_on: "2016-02-29",
@@ -197,7 +243,7 @@ describe("illness start date validation tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`])
       .send({"illness-start-day": "aa", "illness-start-month": "bb", "illness-start-year": "cc"});
     expect(res.status).toEqual(200);
-    expect(res.text).toContain(ILLNESS_START_DATE_INVALID);
+    expect(res.text).toContain(DATE_INVALID);
     expect(mockUpdateReason).not.toHaveBeenCalled();
   });
 

--- a/views/accounts/accounts-date.html
+++ b/views/accounts/accounts-date.html
@@ -59,7 +59,7 @@
       {{ govukDateInput({
         id: "accounts-date",
         namePrefix: "accounts-date",
-        errorMessage: accountsDateError,
+        errorMessage: accountDateErrorMsg,
         fieldset: {
           legend: {
             text: "When did the accounting issue happen?",

--- a/views/other/reason-other.html
+++ b/views/other/reason-other.html
@@ -48,21 +48,24 @@
           }
         }) }}
 
-
         {{ govukTextarea({
           id: "otherInformation",
           name: "otherInformation",
           value: otherInformation,
           errorMessage: otherInformationErr,
           rows: "8",
+          attributes: {
+          "data-event-id": "other-reason-information-input"
+          },
           label: {
             text: "Detailed description of the reason",
             isPageHeading: true,
             classes: "govuk-heading-large"
           }
         }) }}
+
         {{ govukButton({
-           text: "Continue",
+          text: "Continue",
           attributes: {
             "data-event-id": "continue-button",
             id: "submit"


### PR DESCRIPTION
Added functionality to change the way the date pages handle errors, to come in line with GDS standards found here https://design-system.service.gov.uk/components/date-input/

Also added unit tests to cover the new variations of errors on the different pages.