### PR TITLE
Removed page heading class from information labels

### DIFF
--- a/views/accounts/accounts-information.html
+++ b/views/accounts/accounts-information.html
@@ -44,7 +44,6 @@
           rows: '8',
           label: {
             text: "Anything you tell us to support your extension will be kept confidential.",
-            isPageHeading: true,
             classes: "govuk-heading-large"
           }
         }) }}

--- a/views/illness/illness-information.html
+++ b/views/illness/illness-information.html
@@ -43,7 +43,6 @@
         rows: "8",
         label: {
           text: "Anything you tell us to support your application will be kept confidential.",
-          isPageHeading: true,
           classes: "govuk-heading-large"
         },
         errorMessage: errorText

--- a/views/other/reason-other.html
+++ b/views/other/reason-other.html
@@ -59,7 +59,6 @@
           },
           label: {
             text: "Detailed description of the reason",
-            isPageHeading: true,
             classes: "govuk-heading-large"
           }
         }) }}


### PR DESCRIPTION
This was causing the labels to be contained in h1 tags. Removing the isPageHeading option stops this.