### PR TITLE
Added condition to reflect what is in the emails

### DIFF
--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -18,6 +18,7 @@ const createMissingError = (item: string): Error => {
 const route = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const companyNum: string = await sessionService.getCompanyInContext(req.chSession);
   let isMissingAuthenticationCodeJourney: boolean = false;
+  let numOfReasons: number = 0;
   if (!companyNum) {
     return next(createMissingError("Company Number"));
   }
@@ -55,6 +56,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
   if (token && request && activeFeature(FEATURE_MISSING_AUTHENTICATION_CODE)) {
     const requestReasons: ListReasonResponse =
       await getReasons(request, token);
+    numOfReasons = requestReasons.items.length;
     if (requestReasons) {
       requestReasons.items.forEach(
         (reason) => {
@@ -70,6 +72,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     {
       authCodeFlag: isMissingAuthenticationCodeJourney,
       companyNumber: companyNum,
+      numberOfReasons: numOfReasons,
       templateName: templatePaths.CONFIRMATION,
       userEmail: email,
     });

--- a/views/confirmation.html
+++ b/views/confirmation.html
@@ -33,7 +33,12 @@
 
     <h2 class="govuk-heading-m">What happens next</h2>
     <p>It will take up to 5 working days to review your application. We’ll contact you by email with our decision.
-      Accepted applications normally receive an extension of 30 days.
+      Accepted applications normally receive an extension of
+      {% if numberOfReasons === 1 and authCodeFlag === true %}
+        up to 2 weeks.
+      {% else %}
+        30 days.
+      {% endif %}
       We may also contact you if we need more information.</p>
     <p>
       <a href="https://www.research.net/r/extensions-confirmation">What did you think of this service?</a>


### PR DESCRIPTION
A new parameter for the confirmation page to determine the number of reasons and a new conditional to determine whether the extension length is specified as up to two weeks for a single reason that is the auth code missing and 30 days in all other cases. This will reflect what is sent in the application submitted emails.