### PR TITLE
Making build call lint so we can reuse existing build-test-unit ci-co…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 	rm -f ./build.log
 
 .PHONY: build
-build:	update_submodules
+build:	update_submodules lint
 	npm i
 	npm run build
 


### PR DESCRIPTION
…ncourse-resousources task

Common task executes make -C source-code build test-unit. Extensions-web has an extra lint target that is being used so moving lint into the build target to make sure it still gets called.