### PR TITLE
Makefile - lint fails as npm i needs to run before tslint - so moving…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ clean:
 	rm -rf ./dist
 	rm -f ./build.log
 
-.PHONY: build
-build:	update_submodules lint
+package-install:
 	npm i
+
+.PHONY: build
+build:	package-install lint update_submodules
 	npm run build
 
 .PHONY: lint


### PR DESCRIPTION
… npm i to it's own target so we can add as a dependency