### PR TITLE
Feature/add sonar publish as make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ sonar:
 	npm run sonarqube
 
 .PHONY: test
-test: test-unit test-integration
-	npm run test
+test:
+	npm run sonar-test
 
 .PHONY: test-unit
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ build:	package-install lint update_submodules
 lint:
 	npm run lint
 
+.PHONY: sonar-publish
+sonar-publish:
+	npm run sonarqube
+
 .PHONY: test
 test: test-unit test-integration
 	npm run test

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ build:	package-install lint update_submodules
 lint:
 	npm run lint
 
-.PHONY: sonar-publish
-sonar-publish:
+.PHONY: sonar
+sonar:
 	npm run sonarqube
 
 .PHONY: test

--- a/jest.config.sonar.js
+++ b/jest.config.sonar.js
@@ -15,5 +15,5 @@ module.exports = {
       diagnostics: false,
     }
   },
-  globalSetup: "./global.setup.ts",
+  globalSetup: "./src/test/global.setup.ts",
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "contract-consumer": "jest -c src/test/jest.config.contract.js --detectOpenHandles",
     "sass": "node-sass src/public/stylesheets/scss -o src/public/stylesheets/css -i false",
     "lint": "tslint -p .",
-    "sonarqube": "npm run coverage-jest && sonar-scanner",
-    "coverage-jest": "jest -c jest.config.coverage.js --forceExit --coverage"
+    "sonarqube": "sonar-scanner",
+    "sonar-test": "jest -c src/test/jest.config.sonar.js --forceExit --coverage"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sass": "node-sass src/public/stylesheets/scss -o src/public/stylesheets/css -i false",
     "lint": "tslint -p .",
     "sonarqube": "sonar-scanner",
-    "sonar-test": "jest -c src/test/jest.config.sonar.js --forceExit --coverage"
+    "sonar-test": "jest -c jest.config.sonar.js --forceExit --coverage"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/src/test/jest.config.sonar.js
+++ b/src/test/jest.config.sonar.js
@@ -15,5 +15,5 @@ module.exports = {
       diagnostics: false,
     }
   },
-  globalSetup: "./src/test/global.setup.ts",
+  globalSetup: "./global.setup.ts",
 };


### PR DESCRIPTION
I've re-jigged the makefile to create a new sonar target so we can use the common pipeline task to publish to sonar. (pipeline change have been made)