### PR TITLE
Removing duplicate code in choose reason template and feature flag for missing auth code

### DIFF
--- a/src/controllers/choose.reason.controller.ts
+++ b/src/controllers/choose.reason.controller.ts
@@ -22,7 +22,8 @@ export const render = (req: Request, res: Response, next: NextFunction): void =>
   if (!(req.chSession.data[keys.EXTENSION_SESSION] === undefined)) {
     accountingIssuesChecked = req.chSession.data[keys.EXTENSION_SESSION][keys.ACCOUNTING_ISSUES_CHOSEN];
     missingAuthenticationCodeChecked = req.chSession.data
-      [keys.EXTENSION_SESSION][keys.MISSING_AUTHENTICATION_CODE_CHOSEN];
+      [keys.EXTENSION_SESSION]
+      [keys.MISSING_AUTHENTICATION_CODE_CHOSEN];
     illnessChecked = req.chSession.data[keys.EXTENSION_SESSION][keys.ILLNESS_CHOSEN];
     otherChecked = req.chSession.data[keys.EXTENSION_SESSION][keys.OTHER_CHOSEN];
   }

--- a/src/controllers/choose.reason.controller.ts
+++ b/src/controllers/choose.reason.controller.ts
@@ -9,8 +9,6 @@ import * as apiClient from "../client/apiclient";
 import { IExtensionRequest } from "session/types";
 import * as reasonService from "../services/reason.service";
 import * as keys from "../session/keys";
-import activeFeature from "../feature.flag";
-import {FEATURE_MISSING_AUTHENTICATION_CODE} from "../session/config";
 
 const validators = [
   check("extensionReason").not().isEmpty().withMessage(errorMessages.EXTENSION_REASON_NOT_SELECTED),
@@ -23,17 +21,13 @@ export const render = (req: Request, res: Response, next: NextFunction): void =>
   let otherChecked: boolean = false;
   if (!(req.chSession.data[keys.EXTENSION_SESSION] === undefined)) {
     accountingIssuesChecked = req.chSession.data[keys.EXTENSION_SESSION][keys.ACCOUNTING_ISSUES_CHOSEN];
-    if (activeFeature(FEATURE_MISSING_AUTHENTICATION_CODE)) {
-      missingAuthenticationCodeChecked = req.chSession.data
-        [keys.EXTENSION_SESSION]
-        [keys.MISSING_AUTHENTICATION_CODE_CHOSEN];
-    }
+    missingAuthenticationCodeChecked = req.chSession.data
+      [keys.EXTENSION_SESSION][keys.MISSING_AUTHENTICATION_CODE_CHOSEN];
     illnessChecked = req.chSession.data[keys.EXTENSION_SESSION][keys.ILLNESS_CHOSEN];
     otherChecked = req.chSession.data[keys.EXTENSION_SESSION][keys.OTHER_CHOSEN];
   }
   return res.render(templatePaths.CHOOSE_REASON, {
     isAccountingIssuesChecked: accountingIssuesChecked,
-    isFeatureFlagAuthCodeEnabled: activeFeature(FEATURE_MISSING_AUTHENTICATION_CODE),
     isIllnessChecked: illnessChecked,
     isMissingAuthCodeChecked: missingAuthenticationCodeChecked,
     isOtherReasonChecked: otherChecked,
@@ -54,7 +48,6 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
           extReasonErr,
         ],
         extensionReasonErr: extReasonErr,
-        isFeatureFlagAuthCodeEnabled: activeFeature(FEATURE_MISSING_AUTHENTICATION_CODE),
         templateName: templatePaths.CHOOSE_REASON,
       });
     }

--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -8,7 +8,6 @@ import logger from "../logger";
 import activeFeature from "../feature.flag";
 import RequestCountMonitor from "../global/request.count.monitor";
 import {getReasons, ListReasonResponse} from "../client/apiclient";
-import {FEATURE_MISSING_AUTHENTICATION_CODE} from "../session/config";
 
 const createMissingError = (item: string): Error => {
   const errMsg: string = item + " missing from session";
@@ -53,9 +52,8 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     logger.error("Form already submitted, not processing again");
   }
 
-  if (token && request && activeFeature(FEATURE_MISSING_AUTHENTICATION_CODE)) {
-    const requestReasons: ListReasonResponse =
-      await getReasons(request, token);
+  if (token && request) {
+    const requestReasons: ListReasonResponse = await getReasons(request, token);
     if (requestReasons) {
       numOfReasons = requestReasons.items.length;
       requestReasons.items.forEach(

--- a/src/session/config.ts
+++ b/src/session/config.ts
@@ -32,6 +32,8 @@ export const PIWIK_SITE_ID = getEnvironmentValue("PIWIK_SITE_ID");
 
 export const API_URL  = getEnvironmentValue("API_LOCAL_URL");
 
+export const API_KEY  = getEnvironmentValue("CHS_API_KEY");
+
 export const EXTENSIONS_API_URL = getEnvironmentValue("EXTENSIONS_API_URL");
 
 export const EXTENSIONS_PROCESSOR_API_URL = getEnvironmentValue("EXTENSIONS_PROCESSOR_API_URL");

--- a/src/session/config.ts
+++ b/src/session/config.ts
@@ -32,8 +32,6 @@ export const PIWIK_SITE_ID = getEnvironmentValue("PIWIK_SITE_ID");
 
 export const API_URL  = getEnvironmentValue("API_LOCAL_URL");
 
-export const API_KEY  = getEnvironmentValue("CHS_API_KEY");
-
 export const EXTENSIONS_API_URL = getEnvironmentValue("EXTENSIONS_API_URL");
 
 export const EXTENSIONS_PROCESSOR_API_URL = getEnvironmentValue("EXTENSIONS_PROCESSOR_API_URL");
@@ -41,7 +39,5 @@ export const EXTENSIONS_PROCESSOR_API_URL = getEnvironmentValue("EXTENSIONS_PROC
 export const MAXIMUM_EXTENSION_REQUESTS_PER_DAY = getEnvironmentValue("MAXIMUM_EXTENSION_REQUESTS_PER_DAY");
 
 export const FEATURE_REQUEST_COUNT = getEnvironmentValue("FEATURE_REQUEST_COUNT");
-
-export const FEATURE_MISSING_AUTHENTICATION_CODE = getEnvironmentValue("FEATURE_MISSING_AUTHENTICATION_CODE");
 
 export const MAX_FILE_SIZE_BYTES = getEnvironmentValue("MAX_FILE_SIZE_BYTES");

--- a/src/test/controllers/confirmation.controller.spec.unit.ts
+++ b/src/test/controllers/confirmation.controller.spec.unit.ts
@@ -230,9 +230,9 @@ const dummySession = (companyNumber, email) => {
         ]
       }],
     }
-  }
+  };
   return session;
-}
+};
 
 const dummySessionWithToken = (companyNumber, email) => {
   let session: Session = Session.newInstance();
@@ -262,6 +262,6 @@ const dummySessionWithToken = (companyNumber, email) => {
         ]
       }],
     }
-  }
+  };
   return session;
-}
+};

--- a/views/choose-reason.html
+++ b/views/choose-reason.html
@@ -42,58 +42,7 @@
         {% set extensionReasonErrorMessage = false %}
       {% endif %}
 
-      {% if isFeatureFlagAuthCodeEnabled === true %}
-        {{ govukRadios({
-          idPrefix: "choose-reason",
-          name: "extensionReason",
-          errorMessage: extensionReasonErrorMessage,
-          fieldset: {
-            legend: {
-              text: "Why are you applying for an extension?",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
-            }
-          },
-          hint: {
-            text: "You can add more reasons later"
-          },
-          items: [
-            {
-              value: "illness",
-              text: "Illness",
-              checked: isIllnessChecked,
-              attributes: {
-                "data-event-id": "illness-option"
-              }
-            },
-            {
-              value: "missing company authentication code",
-              text: "Missing company authentication code",
-              checked: isMissingAuthCodeChecked,
-              attributes: {
-                "data-event-id": "missing-authentication-code-option"
-              }
-            },
-            {
-              value: "accounting issues",
-              text: "Accounting issues",
-              checked: isAccountingIssuesChecked,
-              attributes: {
-                "data-event-id": "accounting-issues-option"
-              }
-            },
-            {
-              value: "other",
-              text: "I'm applying for another reason",
-              checked: isOtherReasonChecked,
-              attributes: {
-                "data-event-id": "other-option"
-              }
-            }
-          ]
-        }) }}
-      {% else %}
-        {{ govukRadios({
+      {{ govukRadios({
         idPrefix: "choose-reason",
         name: "extensionReason",
         errorMessage: extensionReasonErrorMessage,
@@ -105,7 +54,7 @@
           }
         },
         hint: {
-        text: "You can add more reasons later"
+          text: "You can add more reasons later"
         },
         items: [
           {
@@ -114,6 +63,14 @@
             checked: isIllnessChecked,
             attributes: {
               "data-event-id": "illness-option"
+            }
+          },
+          {
+            value: "missing company authentication code",
+            text: "Missing company authentication code",
+            checked: isMissingAuthCodeChecked,
+            attributes: {
+              "data-event-id": "missing-authentication-code-option"
             }
           },
           {
@@ -134,9 +91,8 @@
           }
         ]
       }) }}
-    {% endif %}
 
-        {{ govukButton({
+      {{ govukButton({
         text: "Continue",
         attributes: {
           "data-event-id": "continue-button",


### PR DESCRIPTION
Sonar is still failing extensions-web due to duplicate code in the choose reason template. This is due to the feature flag for missing auth code causing us to have 2 lists for the page, 1 with and 1 without missing auth code. As this feature flag is no longer needed it is being removed and we will have just the 1 list of reasons.