### PR TITLE
Word change on start page

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -41,14 +41,10 @@
       <a id="start-now" href="/extensions/company-number" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"
          data-event-id="start-now-button" onclick="_paq.push(['trackGoal', 3]);">Start now</a>
       <h2 class="govuk-heading-m">Before you start</h2>
-      <p>
-        You can apply for more time to file if something has happened that is out of your control and you cannot file your company accounts on time.
+      <p>You must send your application to us before your normal filing deadline. You can apply for more time to file if something has happened that is out of your control and you cannot file your company accounts on time. It should include a full
+        explanation of why you need the extension.
       </p>
-      <p>
-        You must send your application to us before your normal filing deadline. It should include a full explanation of why you need the extension.
-      </p>
-      <p>
-        We will not issue you a late filing penalty if your application is approved and you file your accounts before the extended deadline.
+      <p>We will not issue you a late filing penalty if your application is approved and you file your accounts before the extended deadline.
       </p>
     </div>
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
Changed the text under the 'Before you start' header to say to companies that they cannot apply for a filing extension once their filing deadline has passed.