### PR TITLE
Do not copy node modules into image 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!api-enumerations
+!src
+!views
+!package-lock.json
+!package.json
+!tsconfig.json

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,6 +1,6 @@
 local_resource(
   name = 'dev:extensions-web',
-  cmd = 'npm --silent install && npm --silent run build',
+  cmd = 'npm --silent install --only=prod && npm --silent run build',
   deps = ['src']
 )
 


### PR DESCRIPTION
Copying node modules into image is an expensive operation. Installing only production dependencies inside image is quicker.