### PR TITLE
DEBT-1722 Address security vulnerability reported by Sonar

### DIFF
--- a/src/model/page.urls.ts
+++ b/src/model/page.urls.ts
@@ -29,8 +29,10 @@ export const ERROR: string = SEPARATOR + templates.ERROR;
 export const CHECK_YOUR_ANSWERS: string = SEPARATOR + templates.CHECK_YOUR_ANSWERS;
 export const TOO_SOON: string = SEPARATOR + templates.TOO_SOON;
 export const EXTENSION_LIMIT_REACHED: string = SEPARATOR + templates.EXTENSION_LIMIT_REACHED;
+export const DOWNLOAD_SUFFIX: string = "/download";
+export const DOWNLOAD_EXTENSIONS_REQUESTS = "/extensions/requests/";
 export const DOWNLOAD_ATTACHMENT: string =
-  "/company/:companyId/extensions/requests/:requestId/*/attachments/*/download";
+  "/company/:companyId" + DOWNLOAD_EXTENSIONS_REQUESTS + ":requestId/*/attachments/*" + DOWNLOAD_SUFFIX;
 export const BACK_LINK: string =  "/back-link";
 export const ACCESSIBILITY_STATEMENT: string = SEPARATOR + templates.ACCESSIBILITY_STATEMENT;
 export const REASON_ID: string = "reasonId=";

--- a/src/test/authentication/middleware/index.spec.unit.ts
+++ b/src/test/authentication/middleware/index.spec.unit.ts
@@ -41,7 +41,7 @@ describe("Authentication middleware", () => {
     expect(response.status).toEqual(302);
   });
 
-  it("should not redirect to signin if loading accessibility statement page", async () => {
+  it("should NOT redirect to signin if loading accessibility statement page", async () => {
     const response = await request(app)
       .get("/extensions/accessibility-statement")
       .set("Referer", "/extensions");
@@ -58,7 +58,7 @@ describe("Authentication middleware", () => {
     expect(response.status).toEqual(302);
   });
 
-  it("should not redirect to signin if navigating from /extensions page and not signed in", async () => {
+  it("should redirect to signin if navigating from /extensions page and not signed in", async () => {
     setNotSignedIn();
     const response = await request(app)
       .get("/extensions/company-number")
@@ -68,7 +68,7 @@ describe("Authentication middleware", () => {
   });
 
 
-  it("should not redirect to signin if /extensions/* called while signed in", async () => {
+  it("should NOT redirect to signin if /extensions/* called while signed in", async () => {
     const response = await request(app)
       .get("/extensions/company-number")
       .set("Referer", "/")
@@ -76,13 +76,32 @@ describe("Authentication middleware", () => {
     expect(response.status).toEqual(200);
   });
 
-  it("should redirect to original request url if /extensions/*/download called and not signed in", async () => {
+  it("should redirect to signin if /extensions/*/download called and not signed in", async () => {
     setNotSignedIn();
     const url: string = "/extensions/download/company/1234/extensions/requests/5678/reasons/623826183/attachments/a7c4f600/download";
     const response = await request(app)
       .get(url)
       .set("Referer", "/")
       .expect("Location", "/signin?return_to=" + url);
+    expect(response.status).toEqual(302);
+  });
+
+  it("should redirect to start page if invalid download URL supplied and no referer and not signed in", async () => {
+    setNotSignedIn();
+    const url: string = "/extensions/download/company/1234/extensions/NOT-ALLOWED/requests/5678/reasons/623826183/attachments/a7c4f600/download";
+    const response = await request(app)
+      .get(url)
+      .expect("Location", "/extensions");
+    expect(response.status).toEqual(302);
+  });
+
+  it("should redirect to signin and thereafter start page if invalid download URL supplied with referer and not signed in", async () => {
+    setNotSignedIn();
+    const url: string = "/extensions/NOT-ALLOWED/download/company/1234/extensions/requests/5678/reasons/623826183/attachments/a7c4f600/download";
+    const response = await request(app)
+      .get(url)
+      .set("Referer", "/")
+      .expect("Location", "/signin?return_to=/extensions");
     expect(response.status).toEqual(302);
   });
 });


### PR DESCRIPTION
* Fixes the '_Change this code to not perform redirects based on user-controlled
data_' vulnerability, reported on line 35 of `src/authentication/middleware/index.ts`
* Exercises greater control over what 'return URLs' are used for redirection, post sign-in
* Performs additional checks on the download URL supplied to the service
* Tidies up some tests related to the above and adds a couple of new ones
to check the new logic