### PR TITLE
improve rejected promise error handling in extensions-web when missing session returned from redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-20
 WORKDIR /opt
 COPY api-enumerations ./api-enumerations
-COPY dist ./dist
 COPY node_modules ./node_modules
 COPY ./package.json dist ./package-lock.json docker_start.sh ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /opt
 COPY api-enumerations ./api-enumerations
 COPY dist ./dist
 COPY node_modules ./node_modules
-COPY ./package.json ./package-lock.json docker_start.sh ./
+COPY ./package.json dist ./package-lock.json docker_start.sh ./
 
 CMD ["./docker_start.sh"]
 

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -5,7 +5,7 @@ local_resource(
 )
 
 custom_build(
-  ref = '416670754337.dkr.ecr.eu-west-2.amazonaws.com/local/extensions-web:latest',
+  ref = '416670754337.dkr.ecr.eu-west-2.amazonaws.com/extensions-web:latest',
    #the following build-command was updated as specified by https://github.com/companieshouse/docker-chs-development/pull/581
    command = 'docker build --build-arg SSH_PRIVATE_KEY="$(ssh_key_path="$(ssh -G github.com | grep -e \'^identityfile.*\' | head -n1 | sed \'s|^identityfile \\(.*\\)|\\1|\')"; if [ -z "${ssh_key_path}" ]; then echo "Could not find ssh key path for github.com">&2; false; elif [ -f "${ssh_key_path}" ]; then cat "${ssh_key_path}"; else echo "Could not find ssh key for github at ${ssh_key_path}" >&2; false; fi)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
   live_update = [

--- a/src/controllers/choose.reason.controller.ts
+++ b/src/controllers/choose.reason.controller.ts
@@ -59,7 +59,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     if (currentReason && currentReason.reason_status === "DRAFT") {
       await reasonService.deleteCurrentReason(req.chSession);
     }
-  
+
     switch (req.body.extensionReason) {
       case "illness":
         await updateChosenReasonKeys(req, true, false, false, false);
@@ -74,7 +74,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
         return await addReason(req, res, (request) =>
           request.body.extensionReason, templatePaths.REASON_OTHER);
     }
-  } catch(err) {
+  } catch (err) {
     logger.info("Error caught posting a chosen reason");
     return next(err);
   }

--- a/src/controllers/choose.reason.controller.ts
+++ b/src/controllers/choose.reason.controller.ts
@@ -8,6 +8,7 @@ import * as apiClient from "../client/apiclient";
 import { IExtensionRequest } from "session/types";
 import * as reasonService from "../services/reason.service";
 import * as keys from "../session/keys";
+import logger from "../logger";
 
 const validators = [
   check("extensionReason").not().isEmpty().withMessage(errorMessages.EXTENSION_REASON_NOT_SELECTED),
@@ -52,26 +53,30 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
       });
     }
   }
-  await setCheckDetailsToDefault(req);
-
-  const currentReason = await reasonService.getCurrentReason(req.chSession);
-  if (currentReason && currentReason.reason_status === "DRAFT") {
-    await reasonService.deleteCurrentReason(req.chSession);
-  }
-
-  switch (req.body.extensionReason) {
-    case "illness":
-      await updateChosenReasonKeys(req, true, false, false, false);
-      return await addReason(req, res, (request) =>
-        request.body.extensionReason, templatePaths.REASON_ILLNESS);
-    case "accounting issues":
-      await updateChosenReasonKeys(req, false, true, false, false);
-      return await addReason(req, res, (request) =>
-        request.body.extensionReason, templatePaths.REASON_ACCOUNTING_ISSUE);
-    case "other":
-      await updateChosenReasonKeys(req, false, false, false, true);
-      return await addReason(req, res, (request) =>
-        request.body.extensionReason, templatePaths.REASON_OTHER);
+  try {
+    await setCheckDetailsToDefault(req);
+    const currentReason = await reasonService.getCurrentReason(req.chSession);
+    if (currentReason && currentReason.reason_status === "DRAFT") {
+      await reasonService.deleteCurrentReason(req.chSession);
+    }
+  
+    switch (req.body.extensionReason) {
+      case "illness":
+        await updateChosenReasonKeys(req, true, false, false, false);
+        return await addReason(req, res, (request) =>
+          request.body.extensionReason, templatePaths.REASON_ILLNESS);
+      case "accounting issues":
+        await updateChosenReasonKeys(req, false, true, false, false);
+        return await addReason(req, res, (request) =>
+          request.body.extensionReason, templatePaths.REASON_ACCOUNTING_ISSUE);
+      case "other":
+        await updateChosenReasonKeys(req, false, false, false, true);
+        return await addReason(req, res, (request) =>
+          request.body.extensionReason, templatePaths.REASON_OTHER);
+    }
+  } catch(err) {
+    logger.info("Error caught posting a chosen reason");
+    return next(err);
   }
 };
 

--- a/src/controllers/error.controller.ts
+++ b/src/controllers/error.controller.ts
@@ -17,7 +17,8 @@ const notFoundHandler = (req: Request, res: Response, next: NextFunction) => {
  * last handler in the chain for it to work.
  */
 const errorHandler = async (err: unknown, req: Request, res: Response, next: NextFunction) => {
-  logger.error(errorMessages.ERROR_500, err);
+  logger.error(errorMessages.ERROR_500);
+  logger.error(err);
   res.status(500).render(templatePaths.ERROR);
 };
 

--- a/src/controllers/illness/continued.illness.controller.ts
+++ b/src/controllers/illness/continued.illness.controller.ts
@@ -24,7 +24,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
   try {
     const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
     const illnessStartDate: string = formatDateForDisplay(reason.start_on);
-  
+
     if (reason && reason.continued_illness) {
       existingInformation = reason.continued_illness;
     }

--- a/src/controllers/illness/continued.illness.controller.ts
+++ b/src/controllers/illness/continued.illness.controller.ts
@@ -9,6 +9,7 @@ import * as sessionService from "../../services/session.service";
 import * as reasonService from "../../services/reason.service";
 import { ReasonWeb } from "model/reason/extension.reason.web";
 import {formatDateForDisplay} from "../../client/date.formatter";
+import logger from "../../logger";
 
 const validators = [
   check("continuedIllness").not().isEmpty().withMessage(errorMessages.STILL_ILL_ANSWER_NOT_PROVIDED),
@@ -20,56 +21,71 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
     await sessionService.setReasonInContextAsString(req.chSession, req.query.reasonId as string);
   }
 
-  const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
-  const illnessStartDate: string = formatDateForDisplay(reason.start_on);
-
-  if (reason && reason.continued_illness) {
-    existingInformation = reason.continued_illness;
-  }
-  if (existingInformation) {
-    switch (existingInformation) {
-      case "yes":
-        return res.render(templatePaths.CONTINUED_ILLNESS, {
-          isYesChecked: true,
-          startDate: illnessStartDate,
-          templateName: templatePaths.CONTINUED_ILLNESS,
-        });
-      case "no":
-        return res.render(templatePaths.CONTINUED_ILLNESS, {
-          isNoChecked: true,
-          startDate: illnessStartDate,
-          templateName: templatePaths.CONTINUED_ILLNESS,
-        });
+  try {
+    const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
+    const illnessStartDate: string = formatDateForDisplay(reason.start_on);
+  
+    if (reason && reason.continued_illness) {
+      existingInformation = reason.continued_illness;
     }
-  } else {
-    return res.render(templatePaths.CONTINUED_ILLNESS, {
-      startDate: illnessStartDate,
-      templateName: templatePaths.CONTINUED_ILLNESS,
-    });
+    if (existingInformation) {
+      switch (existingInformation) {
+        case "yes":
+          return res.render(templatePaths.CONTINUED_ILLNESS, {
+            isYesChecked: true,
+            startDate: illnessStartDate,
+            templateName: templatePaths.CONTINUED_ILLNESS,
+          });
+        case "no":
+          return res.render(templatePaths.CONTINUED_ILLNESS, {
+            isNoChecked: true,
+            startDate: illnessStartDate,
+            templateName: templatePaths.CONTINUED_ILLNESS,
+          });
+      }
+    } else {
+      return res.render(templatePaths.CONTINUED_ILLNESS, {
+        startDate: illnessStartDate,
+        templateName: templatePaths.CONTINUED_ILLNESS,
+      });
+    }
+  } catch (err) {
+    logger.info("Error caught rendering continued illness")
+    next(err)
   }
 };
 
 export const processForm = [...validators, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    const reason = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
-    const illnessStartDate: string = formatDateForDisplay(reason.start_on);
-    const errMsg: string = errors.array().map((err: ValidationError) => err.msg).pop() as string;
-    if (errMsg) {
-      const continuedIllnessError: GovUkErrorData = createGovUkErrorData(errMsg,
-        "#continued-illness", true, "blank");
-      return res.render(templatePaths.CONTINUED_ILLNESS, {
-        continuedIllnessErr: continuedIllnessError,
-        errorList: [
-          continuedIllnessError,
-        ],
-        startDate: illnessStartDate,
-        templateName: templatePaths.CONTINUED_ILLNESS,
-      });
+    try {
+      const reason = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
+      const illnessStartDate: string = formatDateForDisplay(reason.start_on);
+      const errMsg: string = errors.array().map((err: ValidationError) => err.msg).pop() as string;
+      if (errMsg) {
+        const continuedIllnessError: GovUkErrorData = createGovUkErrorData(errMsg,
+          "#continued-illness", true, "blank");
+        return res.render(templatePaths.CONTINUED_ILLNESS, {
+          continuedIllnessErr: continuedIllnessError,
+          errorList: [
+            continuedIllnessError,
+          ],
+          startDate: illnessStartDate,
+          templateName: templatePaths.CONTINUED_ILLNESS,
+        });
+      }
+    } catch (err) {
+      logger.info("Exception caught rendering continued illness page with errors");
+      return next(err);
     }
   } else {
     const answer: string = req.body.continuedIllness;
-    await reasonService.updateReason(req.chSession, {continued_illness: answer});
+    try {
+      await reasonService.updateReason(req.chSession, {continued_illness: answer});
+    } catch (err) {
+      logger.info("Error caught updating reason with continuing illness");
+      return next(err);
+    }
 
     const changingDetails = req.chSession.data[keys.CHANGING_DETAILS];
     if (answer === "yes") {

--- a/src/controllers/illness/continued.illness.controller.ts
+++ b/src/controllers/illness/continued.illness.controller.ts
@@ -51,7 +51,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
     }
   } catch (err) {
     logger.info("Error caught rendering continued illness")
-    next(err)
+    return next(err)
   }
 };
 

--- a/src/controllers/illness/illness.end.date.controller.ts
+++ b/src/controllers/illness/illness.end.date.controller.ts
@@ -11,6 +11,7 @@ import * as sessionService from "../../services/session.service";
 import * as templatePaths from "../../model/template.paths";
 import { ReasonWeb } from "model/reason/extension.reason.web";
 import {formatDateForDisplay, formatDateForReason} from "../../client/date.formatter";
+import logger from "../../logger";
 
 const ILLNESS_END_DAY_FIELD: string = "illness-end-day";
 const ILLNESS_END_MONTH_FIELD: string = "illness-end-month";
@@ -63,26 +64,31 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
   if (req.query.reasonId) {
     await sessionService.setReasonInContextAsString(req.chSession, req.query.reasonId as string);
   }
-  let dateStr;
-  const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
-  if (reason && reason.end_on) {
-    dateStr = reason.end_on;
-  }
-  const illnessStartDate: string = formatDateForDisplay(reason.start_on);
-  if (dateStr) {
-    const endDate: Date = new Date(dateStr);
-    return res.render(templatePaths.ILLNESS_END_DATE, {
-      illnessEndDay: endDate.getDate(),
-      illnessEndMonth: endDate.getMonth() + 1,
-      illnessEndYear: endDate.getFullYear(),
-      startDate: illnessStartDate,
-      templateName: templatePaths.ILLNESS_END_DATE,
-    });
-  } else {
-    return res.render(templatePaths.ILLNESS_END_DATE, {
-      startDate: illnessStartDate,
-      templateName: templatePaths.ILLNESS_END_DATE,
-    });
+  try {
+    let dateStr;
+    const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
+    if (reason && reason.end_on) {
+      dateStr = reason.end_on;
+    }
+    const illnessStartDate: string = formatDateForDisplay(reason.start_on);
+    if (dateStr) {
+      const endDate: Date = new Date(dateStr);
+      return res.render(templatePaths.ILLNESS_END_DATE, {
+        illnessEndDay: endDate.getDate(),
+        illnessEndMonth: endDate.getMonth() + 1,
+        illnessEndYear: endDate.getFullYear(),
+        startDate: illnessStartDate,
+        templateName: templatePaths.ILLNESS_END_DATE,
+      });
+    } else {
+      return res.render(templatePaths.ILLNESS_END_DATE, {
+        startDate: illnessStartDate,
+        templateName: templatePaths.ILLNESS_END_DATE,
+      });
+    }
+  } catch (err) {
+    logger.info("Error caught rendering illness end date page");
+    return next(err);
   }
 };
 
@@ -104,7 +110,13 @@ export const processForm = [extractFullDate, ...validators,
     let href: string = "";
     let isFirstError: boolean = true;
 
-    const reasonErr = await getCurrentExtensionReason(req);
+    let reasonErr: ReasonWeb;
+    try {
+      reasonErr = await getCurrentExtensionReason(req);
+    } catch (err) {
+      logger.info("Exception thrown retrieving Reason in illness.end.data.controller processForm");
+      return next(err);
+    }
     const illnessStartDate: string = reasonErr.start_on;
 
     errors.array({ onlyFirstError: true })
@@ -154,7 +166,12 @@ export const processForm = [extractFullDate, ...validators,
     });
   }
 
-  await reasonService.updateReason(req.chSession, {end_on: formatDateForReason(day, month, year)});
+  try {
+    await reasonService.updateReason(req.chSession, {end_on: formatDateForReason(day, month, year)});
+  } catch(err) {
+    logger.info("Error caught updating Reason with illness end date");
+    return next(err);
+  }
   const changingDetails = req.chSession.data[keys.CHANGING_DETAILS];
   if (changingDetails) {
     return res.redirect(pageURLs.EXTENSIONS_CHECK_YOUR_ANSWERS);

--- a/src/controllers/illness/illness.end.date.controller.ts
+++ b/src/controllers/illness/illness.end.date.controller.ts
@@ -168,7 +168,7 @@ export const processForm = [extractFullDate, ...validators,
 
   try {
     await reasonService.updateReason(req.chSession, {end_on: formatDateForReason(day, month, year)});
-  } catch(err) {
+  } catch (err) {
     logger.info("Error caught updating Reason with illness end date");
     return next(err);
   }

--- a/src/controllers/illness/illness.end.date.controller.ts
+++ b/src/controllers/illness/illness.end.date.controller.ts
@@ -114,7 +114,7 @@ export const processForm = [extractFullDate, ...validators,
     try {
       reasonErr = await getCurrentExtensionReason(req);
     } catch (err) {
-      logger.info("Exception thrown retrieving Reason in illness.end.data.controller processForm");
+      logger.info("Exception thrown retrieving Reason in illness.end.date.controller processForm");
       return next(err);
     }
     const illnessStartDate: string = reasonErr.start_on;

--- a/src/controllers/illness/illness.information.controller.ts
+++ b/src/controllers/illness/illness.information.controller.ts
@@ -41,7 +41,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         templateName: templatePaths.ILLNESS_INFORMATION,
       });
     }
-  } catch(err) {
+  } catch (err) {
     logger.info("Error rendering illness information page");
     return next(err);
   }

--- a/src/controllers/illness/illness.information.controller.ts
+++ b/src/controllers/illness/illness.information.controller.ts
@@ -9,6 +9,7 @@ import * as reasonService from "../../services/reason.service";
 import * as sessionService from "../../services/session.service";
 import {removeNonPrintableChars} from "../../global/string.formatter";
 import {ReasonWeb} from "../../model/reason/extension.reason.web";
+import logger from "../../logger";
 
 const validators = [
   check("illnessInformation").custom((reason, {req}) => {
@@ -24,20 +25,25 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
   if (req.query.reasonId) {
     await sessionService.setReasonInContextAsString(req.chSession, req.query.reasonId as string);
   }
-  const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
-  let existingInformation;
-  if (reason && reason.reason_information) {
-    existingInformation = reason.reason_information;
-  }
-  if (existingInformation) {
-    return res.render(templatePaths.ILLNESS_INFORMATION, {
-      information: existingInformation,
-      templateName: templatePaths.ILLNESS_INFORMATION,
-    });
-  } else {
-    return res.render(templatePaths.ILLNESS_INFORMATION, {
-      templateName: templatePaths.ILLNESS_INFORMATION,
-    });
+  try {
+    const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
+    let existingInformation;
+    if (reason && reason.reason_information) {
+      existingInformation = reason.reason_information;
+    }
+    if (existingInformation) {
+      return res.render(templatePaths.ILLNESS_INFORMATION, {
+        information: existingInformation,
+        templateName: templatePaths.ILLNESS_INFORMATION,
+      });
+    } else {
+      return res.render(templatePaths.ILLNESS_INFORMATION, {
+        templateName: templatePaths.ILLNESS_INFORMATION,
+      });
+    }
+  } catch(err) {
+    logger.info("Error rendering illness information page");
+    return next(err);
   }
 };
 
@@ -57,9 +63,15 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     });
   }
 
-  await reasonService.updateReason(
-    req.chSession,
-    {reason_information: removeNonPrintableChars(req.body.illnessInformation)});
+  try {
+    await reasonService.updateReason(
+      req.chSession,
+      {reason_information: removeNonPrintableChars(req.body.illnessInformation)}
+    );
+  } catch (err) {
+    logger.info("Error caught updating reason with illness information");
+    return next(err);
+  }
 
   const changingDetails = req.chSession.data[keys.CHANGING_DETAILS];
   if (changingDetails) {

--- a/src/controllers/illness/who.was.ill.controller.ts
+++ b/src/controllers/illness/who.was.ill.controller.ts
@@ -42,7 +42,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
       otherPersonValue: "",
       templateName: templatePaths.REASON_ILLNESS,
     };
-  
+
     if (reason && reason.affected_person) {
       existingWhoWasIll = reason.affected_person;
       switch (existingWhoWasIll) {
@@ -64,7 +64,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
           break;
       }
     }
-  
+
     if (existingWhoWasIll) {
       return res.render(templatePaths.REASON_ILLNESS, renderOptions);
     } else {

--- a/src/controllers/other/reason.other.controller.ts
+++ b/src/controllers/other/reason.other.controller.ts
@@ -44,7 +44,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
       existingReason = reason.reason;
       existingInformation = reason.reason_information;
     }
-  
+
     if (existingInformation) {
       return res.render(templatePaths.REASON_OTHER, {
         otherInformation: existingInformation,

--- a/src/controllers/other/reason.other.controller.ts
+++ b/src/controllers/other/reason.other.controller.ts
@@ -9,6 +9,7 @@ import * as reasonService from "../../services/reason.service";
 import * as sessionService from "../../services/session.service";
 import {removeNonPrintableChars} from "../../global/string.formatter";
 import {ReasonWeb} from "../../model/reason/extension.reason.web";
+import logger from "../../logger";
 
 const OTHER_REASON_FIELD: string = "otherReason";
 const OTHER_INFORMATION_FIELD: string = "otherInformation";
@@ -35,24 +36,29 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
   if (req.query.reasonId) {
     await sessionService.setReasonInContextAsString(req.chSession, req.query.reasonId as string);
   }
-  const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
-  let existingReason;
-  let existingInformation;
-  if (reason && (reason.reason_information || reason.reason)) {
-    existingReason = reason.reason;
-    existingInformation = reason.reason_information;
-  }
-
-  if (existingInformation) {
-    return res.render(templatePaths.REASON_OTHER, {
-      otherInformation: existingInformation,
-      otherReason: existingReason,
-      templateName: templatePaths.REASON_OTHER,
-    });
-  } else {
-    return res.render(templatePaths.REASON_OTHER, {
-      templateName: templatePaths.REASON_OTHER,
-    });
+  try {
+    const reason: ReasonWeb = await reasonService.getCurrentReason(req.chSession) as ReasonWeb;
+    let existingReason;
+    let existingInformation;
+    if (reason && (reason.reason_information || reason.reason)) {
+      existingReason = reason.reason;
+      existingInformation = reason.reason_information;
+    }
+  
+    if (existingInformation) {
+      return res.render(templatePaths.REASON_OTHER, {
+        otherInformation: existingInformation,
+        otherReason: existingReason,
+        templateName: templatePaths.REASON_OTHER,
+      });
+    } else {
+      return res.render(templatePaths.REASON_OTHER, {
+        templateName: templatePaths.REASON_OTHER,
+      });
+    }
+  } catch (err) {
+    logger.info("Error caught rendering reason other page");
+    return next(err);
   }
 };
 
@@ -97,12 +103,18 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
 
   const changingDetails = req.chSession.data[keys.CHANGING_DETAILS];
   const reasonInput = req.body.otherReason;
-  await reasonService.updateReason(
-    req.chSession,
-    {
-      reason: removeNonPrintableChars(reasonInput),
-      reason_information: removeNonPrintableChars(req.body.otherInformation),
-    });
+  try {
+    await reasonService.updateReason(
+      req.chSession,
+      {
+        reason: removeNonPrintableChars(reasonInput),
+        reason_information: removeNonPrintableChars(req.body.otherInformation),
+      });
+  } catch (err) {
+    logger.info("Error caught posting other reason");
+    return next(err);
+  }
+
   if (changingDetails) {
     return res.redirect(pageURLs.EXTENSIONS_CHECK_YOUR_ANSWERS);
   } else {

--- a/src/controllers/remove.document.controller.ts
+++ b/src/controllers/remove.document.controller.ts
@@ -9,13 +9,20 @@ import * as errorMessages from "../model/error.messages";
 import {createGovUkErrorData, GovUkErrorData} from "../model/govuk.error.data";
 import * as templatePaths from "../model/template.paths";
 import * as reasonService from "../services/reason.service";
+import { ReasonWeb } from "model/reason/extension.reason.web";
 
 const validators = [
   check("removeDocument").not().isEmpty().withMessage(errorMessages.REMOVE_DOCUMENT_DECISION_NOT_MADE),
 ];
 
 export const render = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  const reason = await reasonService.getReasonFromFullRequest(req);
+  let reason: ReasonWeb | undefined;
+  try {
+    reason = await reasonService.getReasonFromFullRequest(req);
+  } catch (err) {
+    logger.info("Error caught retrieving reason from request");
+    return next(err);
+  }
   if (reason) {
     const attachment = reason.attachments.filter((attachmentItem) => attachmentItem.id === req.query.documentID).pop();
     if (attachment) {

--- a/src/services/reason.service.ts
+++ b/src/services/reason.service.ts
@@ -54,5 +54,5 @@ const processReason = async (chSession: Session, apiClientFunction, body?): Prom
     return body ? await apiClientFunction(request, token, body) :
       await apiClientFunction(request, token);
   }
-  return Promise.reject("invalid session data");
+  return Promise.reject("invalid session data when processing reason");
 };

--- a/src/test/controllers/accounts/accounts.date.controller.spec.unit.ts
+++ b/src/test/controllers/accounts/accounts.date.controller.spec.unit.ts
@@ -106,6 +106,38 @@ describe("accounting issue date url tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
   });
+
+  it("should return 500 when missing session data", async () => {
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .get(PageURLs.EXTENSIONS_REASON_ACCOUNTING_ISSUE)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+    expect(mockGetCurrentReason).toBeCalledWith({
+      "_cookieId": "cookie",
+      "_data": {
+        "extension_session": {
+          "company_in_context": "00006400",
+          "extension_requests": [
+            {
+              "company_number": "00006400",
+              "extension_request_id": "request1",
+              "reason_in_context_string": "reason1"
+            }
+          ]
+        },
+        "page_history": {"page_history": ["/"]},
+        "signin_info": {
+          "access_token": {"access_token": "KGGGUYUYJHHVK1234"},
+          "signed_in": 1,
+          "user_profile": {"email": "demo@ch.gov.uk"}
+        }
+      }
+    });
+  });
 });
 
 describe("accounts date validation tests", () => {

--- a/src/test/controllers/accounts/accounts.information.controller.spec.unit.ts
+++ b/src/test/controllers/accounts/accounts.information.controller.spec.unit.ts
@@ -72,6 +72,17 @@ describe("accounts information url tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
   });
+
+  it ("should return 500 if missing session info", async () => {
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_ACCOUNTS_INFORMATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+  });
 });
 
 describe("accounts information validation tests", () => {

--- a/src/test/controllers/choose.reason.controller.spec.unit.ts
+++ b/src/test/controllers/choose.reason.controller.spec.unit.ts
@@ -3,7 +3,7 @@ import * as superTest from "supertest";
 import * as pageURLs from "../../model/page.urls";
 import {COOKIE_NAME} from "../../session/config";
 import {loadSession} from "../../services/redis.service";
-import {loadMockSession} from "../mock.utils";
+import {loadMockSession, missingTokenDummySession} from "../mock.utils";
 import * as keys from "../../session/keys";
 import Session from "../../session/session";
 import {addExtensionReasonToRequest} from "../../client/apiclient";
@@ -131,6 +131,22 @@ describe("choose reason validation tests", () => {
         otherReason: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       });
     expect(mockDeleteReason).toHaveBeenCalled();
+    expect(mockGetCurrentReason).toHaveBeenCalled();
+  });
+
+  it("should call delete reason if current reason in draft mode", async () => {
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await superTest(app)
+      .post(pageURLs.EXTENSIONS_CHOOSE_REASON)
+      .set("Accept", "application/json")
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        extensionReason: "other",
+      });
+    expect(res.status).toEqual(500);
     expect(mockGetCurrentReason).toHaveBeenCalled();
   });
 });

--- a/src/test/controllers/illness/continued.illness.controller.spec.unit.ts
+++ b/src/test/controllers/illness/continued.illness.controller.spec.unit.ts
@@ -69,6 +69,19 @@ describe("continued illness url tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
   });
+
+  it ("should return 500 if continued illness page with missing session", async () => {
+    mockGetCurrentReason.mockRestore();
+    mockGetCurrentReason.mockClear();
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_CONTINUED_ILLNESS)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+  });
 });
 
 describe("continued illness validation tests", () => {

--- a/src/test/controllers/illness/continued.illness.controller.spec.unit.ts
+++ b/src/test/controllers/illness/continued.illness.controller.spec.unit.ts
@@ -17,6 +17,7 @@ const mockCacheService = (<unknown>loadSession as jest.Mock<typeof loadSession>)
 const mockSetReasonInContextAsString = (<unknown>sessionService.setReasonInContextAsString as jest.Mock<typeof sessionService.setReasonInContextAsString>);
 const mockGetCurrentReason = (<unknown>reasonService.getCurrentReason as jest.Mock<typeof reasonService.getCurrentReason>);
 const mockCreateHistoryIfNone = (<unknown>createHistoryIfNone as jest.Mock<typeof createHistoryIfNone>);
+const mockUpdateCurrentReason = (<unknown>reasonService.updateReason as jest.Mock<typeof reasonService.updateReason>);
 
 const REASON_ID: string = "abc-123";
 const STILL_ILL_ANSWER_NOT_PROVIDED: string =
@@ -38,6 +39,7 @@ beforeEach(() => {
       page_history: [],
     };
   });
+  mockUpdateCurrentReason.mockClear();
 });
 
 describe("continued illness url tests", () => {
@@ -139,5 +141,19 @@ describe("continued illness validation tests", () => {
     expect(mockGetCurrentReason).not.toBeCalled();
   });
 
+  it("should receive no error message when an answer of yes is provided", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(fullDummySession);
+    mockUpdateCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_CONTINUED_ILLNESS)
+      .set("Accept", "application/json")
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({continuedIllness: "yes"});
+    expect(res.status).toEqual(500);
+    expect(mockGetCurrentReason).not.toBeCalled();
+  });
 });
 

--- a/src/test/controllers/illness/illness.information.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.information.controller.spec.unit.ts
@@ -65,6 +65,17 @@ describe("illness information url tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
   });
+
+  it ("should return 500 if missing session info", async () => {
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_ILLNESS_INFORMATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+  });
 });
 
 describe("illness information validation tests", () => {

--- a/src/test/controllers/illness/illness.start.date.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.start.date.controller.spec.unit.ts
@@ -105,6 +105,17 @@ describe("illness start date url tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
   });
+
+  it("missing session information throws 500 error", async () => {
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .get(PageURLs.EXTENSIONS_ILLNESS_START_DATE + "?reasonId=" + REASON_ID)
+      .set("Referer", "/test")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+  });
 });
 
 describe("illness start date validation tests", () => {

--- a/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
+++ b/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
@@ -68,7 +68,7 @@ describe("who was ill url tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(200);
-    expect(stringify(res)).toContain("Company%20director%20or%20officer%22%20checked");
+    expect(res.text).toContain("value=\"Company director or officer\" checked");
     expect(mockSetReasonInContextAsString).not.toBeCalled();
     expect(mockGetCurrentReason).toBeCalled();
   });
@@ -80,7 +80,7 @@ describe("who was ill url tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(200);
-    expect(stringify(res)).toContain("Company%20accountant%20or%20agent%22%20checked");
+    expect(res.text).toContain("value=\"Company accountant or agent\" checked");
     expect(mockSetReasonInContextAsString).not.toBeCalled();
     expect(mockGetCurrentReason).toBeCalled();
   });
@@ -92,7 +92,7 @@ describe("who was ill url tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(200);
-    expect(stringify(res)).toContain("Family%20member%22%20checked");
+    expect(res.text).toContain("value=\"Family member\" checked");
     expect(mockSetReasonInContextAsString).not.toBeCalled();
     expect(mockGetCurrentReason).toBeCalled();
   });
@@ -104,7 +104,7 @@ describe("who was ill url tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(200);
-    expect(stringify(res)).toContain("Company%20employee%22%20checked");
+    expect(res.text).toContain("value=\"Company employee\" checked");
     expect(mockSetReasonInContextAsString).not.toBeCalled();
     expect(mockGetCurrentReason).toBeCalled();
   });

--- a/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
+++ b/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
@@ -126,6 +126,18 @@ describe("who was ill url tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
   });
+
+  it("should find who was ill page with existing reason information when reason id is added for change", async () => {
+    mockGetCurrentReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_REASON_ILLNESS + "?reasonId=" + REASON_ID)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+    expect(mockGetCurrentReason).toBeCalled();
+  });
 });
 
 describe("who was ill validation tests", () => {
@@ -201,5 +213,21 @@ describe("who was ill validation tests", () => {
     expect(mockUpdateReason).toHaveBeenCalledWith(fullDummySession(), {
       affected_person: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     });
+  });
+
+  it("should receive 500 when missing session data", async () => {
+    mockUpdateReason.mockImplementation(() => {
+      throw new Error("invalid session data when processing reason");
+    });
+    const res = await request(app)
+      .post(pageURLs.EXTENSIONS_REASON_ILLNESS)
+      .set("Accept", "application/json")
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        illPerson: "other",
+        otherPerson: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      });
+    expect(res.status).toEqual(500);
   });
 });

--- a/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
+++ b/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
@@ -4,10 +4,12 @@ import * as pageURLs from "../../../model/page.urls";
 import {COOKIE_NAME} from "../../../session/config";
 import {loadMockSession, fullDummySession} from "../../mock.utils";
 import {loadSession} from "../../../services/redis.service";
+import {ReasonWeb} from "../../../model/reason/extension.reason.web";
 import {updateReason} from "../../../services/reason.service";
 import * as reasonService from "../../../services/reason.service";
 import * as sessionService from "../../../services/session.service";
 import {createHistoryIfNone} from "../../../services/session.service";
+import { stringify } from "querystring";
 
 jest.mock("../../../services/redis.service");
 jest.mock("../../../services/reason.service");
@@ -23,6 +25,15 @@ const mockCreateHistoryIfNone = (<unknown>createHistoryIfNone as jest.Mock<typeo
 const REASON_ID: string = "abc-123";
 const WHO_WAS_ILL_NOT_SELECTED = "You must select a person";
 const WHO_WAS_ILL_OTHER_TEXT_NOT_PROVIDED = "You must tell us the person";
+function reason(affectedPerson) {
+  return {
+    "id": "1",
+    "reason": "string",
+    "start_on": "string",
+    "end_on": "string",
+    "affected_person": affectedPerson
+  } as ReasonWeb;
+};
 
 beforeEach( () => {
   mockCacheService.mockRestore();
@@ -46,6 +57,54 @@ describe("who was ill url tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(200);
+    expect(mockSetReasonInContextAsString).not.toBeCalled();
+    expect(mockGetCurrentReason).toBeCalled();
+  });
+
+  it("should find who was ill page with get existing director", async () => {
+    mockGetCurrentReason.prototype.constructor.mockImplementation(() => reason("Company director or officer"));
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_REASON_ILLNESS)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(200);
+    expect(stringify(res)).toContain("Company%20director%20or%20officer%22%20checked");
+    expect(mockSetReasonInContextAsString).not.toBeCalled();
+    expect(mockGetCurrentReason).toBeCalled();
+  });
+
+  it("should find who was ill page with get existing agen", async () => {
+    mockGetCurrentReason.prototype.constructor.mockImplementation(() => reason("Company accountant or agent"));
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_REASON_ILLNESS)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(200);
+    expect(stringify(res)).toContain("Company%20accountant%20or%20agent%22%20checked");
+    expect(mockSetReasonInContextAsString).not.toBeCalled();
+    expect(mockGetCurrentReason).toBeCalled();
+  });
+
+  it("should find who was ill page with get existing family member", async () => {
+    mockGetCurrentReason.prototype.constructor.mockImplementation(() => reason("Family member"));
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_REASON_ILLNESS)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(200);
+    expect(stringify(res)).toContain("Family%20member%22%20checked");
+    expect(mockSetReasonInContextAsString).not.toBeCalled();
+    expect(mockGetCurrentReason).toBeCalled();
+  });
+
+  it("should find who was ill page with get existing employee", async () => {
+    mockGetCurrentReason.prototype.constructor.mockImplementation(() => reason("Company employee"));
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_REASON_ILLNESS)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(200);
+    expect(stringify(res)).toContain("Company%20employee%22%20checked");
     expect(mockSetReasonInContextAsString).not.toBeCalled();
     expect(mockGetCurrentReason).toBeCalled();
   });

--- a/src/test/controllers/other/reason.other.controller.spec.unit.ts
+++ b/src/test/controllers/other/reason.other.controller.spec.unit.ts
@@ -69,6 +69,17 @@ describe("reason other url tests", () => {
   });
 });
 
+it("should return 500 if current reason throws exception", async () => {
+  mockGetCurrentReason.mockImplementation(() => {
+    throw new Error("invalid session data when processing reason");
+  });
+  const res = await request(app)
+    .get(pageURLs.EXTENSIONS_REASON_OTHER + "?reasonId=" + REASON_ID)
+    .set("Referer", "/")
+    .set("Cookie", [`${COOKIE_NAME}=123`]);
+  expect(res.status).toEqual(500);
+});
+
 describe("reason other validation tests", () => {
 
   it("should receive error message requesting more information when text input and reason input is empty", async () => {

--- a/src/test/controllers/remove.document.controller.spec.unit.ts
+++ b/src/test/controllers/remove.document.controller.spec.unit.ts
@@ -2,7 +2,7 @@ import * as request from "supertest";
 import app from "../../app";
 import * as pageURLs from "../../model/page.urls";
 import {COOKIE_NAME} from "../../session/config";
-import {fullDummySession} from "../mock.utils";
+import {fullDummySession, missingTokenDummySession} from "../mock.utils";
 import {loadSession} from "../../services/redis.service";
 import {
   getCompanyProfile,
@@ -72,6 +72,14 @@ describe("remove document url tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
     expect(res.status).toEqual(404);
+  });
+  it ("should return 500 if missing session data", async () => {
+    mockCacheService.prototype.constructor.mockImplementationOnce(missingTokenDummySession);
+    const res = await request(app)
+      .get(pageURLs.EXTENSIONS_REMOVE_DOCUMENT + QUERY_ID)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
   });
 });
 

--- a/src/test/mock.utils.ts
+++ b/src/test/mock.utils.ts
@@ -73,6 +73,33 @@ export const fullDummySession = () => {
   return session;
 };
 
+export const missingTokenDummySession = () => {
+  let session = Session.newWithCookieId("cookie");
+  session.data = {
+    [keys.SIGN_IN_INFO]: {
+      [keys.SIGNED_IN]: 1,
+      [keys.USER_PROFILE]: {
+        [keys.USER_ID]: "123",
+      },
+      [keys.USER_PROFILE]: {
+        email: EMAIL
+      }
+    },
+    [keys.EXTENSION_SESSION]: {
+      [keys.COMPANY_IN_CONTEXT]: "00006400",
+      [keys.EXTENSION_REQUESTS]: [{
+        [keys.COMPANY_NUMBER]: "00006400",
+        "extension_request_id": "request1",
+        "reason_in_context_string": "reason1",
+      }]
+    },
+    [keys.PAGE_HISTORY]: {
+      page_history: []
+    }
+  };
+  return session;
+};
+
 export const sessionWithChangingDetails = () => {
   let session = Session.newInstance();
   session.data = {

--- a/src/test/services/reason.service.spec.unit.ts
+++ b/src/test/services/reason.service.spec.unit.ts
@@ -41,7 +41,7 @@ describe("reason service tests", () => {
     try {
       await reasonService.updateReason(session, {illPerson: "joe"});
     } catch (e) {
-      expect(e).toEqual("invalid session data");
+      expect(e).toEqual("invalid session data when processing reason");
     }
 
     expect(mockUpdateReason).not.toBeCalled();
@@ -54,7 +54,7 @@ describe("reason service tests", () => {
     try {
       await reasonService.updateReason(session, {illPerson: "joe"});
     } catch (e) {
-      expect(e).toEqual("invalid session data");
+      expect(e).toEqual("invalid session data when processing reason");
     }
 
     expect(mockUpdateReason).not.toBeCalled();


### PR DESCRIPTION
Add more error handling to responses from processReason call to prevent the application restarting on a rejected promise.

https://companieshouse.atlassian.net/browse/CC-1207