### PR TITLE
LIVE issue - log out session signin_info data

### DIFF
--- a/src/services/redis.service.ts
+++ b/src/services/redis.service.ts
@@ -25,7 +25,7 @@ const loadSession = async (cookieId: string): Promise<Session> => {
   return session;
 };
 
-const logSignInInfo = (chSession: Session, saveOrLoadText: String, cookieId?) => {
+const logSignInInfo = (chSession: Session, saveOrLoadText: string, cookieId?) => {
   const copyOfSignInInfo = structuredClone(chSession["_data"]?.signin_info);
 
   if (copyOfSignInInfo?.access_token?.access_token) {

--- a/src/services/redis.service.ts
+++ b/src/services/redis.service.ts
@@ -1,3 +1,4 @@
+import logger from "../logger";
 import Session from "../session/session";
 import redisStore from "../session/store/redis.store";
 
@@ -6,6 +7,7 @@ import redisStore from "../session/store/redis.store";
  * @param chSession
  */
 const saveSession = async (chSession: Session): Promise<void> => {
+  logSignInInfo(chSession, "SAVING");
   await redisStore.save(chSession);
 };
 
@@ -15,8 +17,24 @@ const saveSession = async (chSession: Session): Promise<void> => {
  */
 const loadSession = async (cookieId: string): Promise<Session> => {
   const session: Session = Session.newWithCookieId(cookieId);
-  session.data = await redisStore.getData(session.sessionKey());
+  const sessionKey = session.sessionKey();
+
+  logger.info("src/services/redis.service.ts - LOADING session from Redis with cookieId = " + cookieId + ", sessionKey = " + sessionKey);
+  session.data = await redisStore.getData(sessionKey);
+  logSignInInfo(session, "LOADED", cookieId);
   return session;
+};
+
+const logSignInInfo = (chSession: Session, saveOrLoadText: String, cookieId?) => {
+  const copyOfSignInInfo = structuredClone(chSession["_data"]?.signin_info);
+
+  if (copyOfSignInInfo?.access_token?.access_token) {
+    copyOfSignInInfo.access_token.access_token = "*** HIDDEN ***";
+  }
+  if (copyOfSignInInfo?.access_token?.refresh_token) {
+    copyOfSignInInfo.access_token.refresh_token = "*** HIDDEN ***";
+  }
+  logger.info(`src/services/redis.service.ts - ${saveOrLoadText} session to/from Redis with sessionKey = ${chSession?.sessionKey()} , cookieId = ${cookieId}, signin_info = ${JSON.stringify(copyOfSignInInfo, null, 2)}`);
 };
 
 export {saveSession, loadSession};

--- a/src/test/global.setup.ts
+++ b/src/test/global.setup.ts
@@ -24,5 +24,4 @@ export default async () => {
   process.env.SHOW_SERVICE_UNAVAILABLE_PAGE = "off";
   process.env.TOO_SOON_DAYS_BEFORE_DUE_DATE="273";
   process.env.MAX_EXTENSION_PERIOD_IN_MONTHS="12"
-  process.env.LOG_SIGNIN_INFO="on";
 };

--- a/src/test/global.setup.ts
+++ b/src/test/global.setup.ts
@@ -24,4 +24,5 @@ export default async () => {
   process.env.SHOW_SERVICE_UNAVAILABLE_PAGE = "off";
   process.env.TOO_SOON_DAYS_BEFORE_DUE_DATE="273";
   process.env.MAX_EXTENSION_PERIOD_IN_MONTHS="12"
+  process.env.LOG_SIGNIN_INFO="on";
 };

--- a/src/test/services/redis.service.spec.unit.ts
+++ b/src/test/services/redis.service.spec.unit.ts
@@ -1,0 +1,101 @@
+jest.mock("ioredis");
+jest.mock("../../session/store/redis.store");
+jest.mock("../../feature.flag");
+jest.mock("../../logger");
+
+import { loadSession, saveSession } from "../../services/redis.service";
+import Session from "../../session/session";
+import redisStore from "../../session/store/redis.store";
+import activeFeature from "../../feature.flag";
+import logger from "../../logger";
+
+const mockLoggerInfo = logger.info as jest.Mock;
+const mockActiveFeature = activeFeature as jest.Mock;
+const mockRedisStoreSave = redisStore.save as jest.Mock;
+const mockRedisStoreGetData = redisStore.getData as jest.Mock;
+
+const COOKIE_ID = "123456789";
+
+describe("redis service tests", () => {
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockActiveFeature.mockReturnValue(false);
+
+  });
+
+  it("Should call save on redisStore", async () => {
+    const session = Session.newInstance();
+
+    await saveSession(session);
+
+    expect(mockRedisStoreSave).toHaveBeenCalledTimes(1);
+    expect(mockRedisStoreSave.mock.calls[0][0]).toEqual(session);
+  });
+
+  it("Should log session info on save when flag is on", async () => {
+    mockActiveFeature.mockReturnValue(true);
+    const session = Session.newInstance();
+
+    await saveSession(session);
+
+    const logMessage = mockLoggerInfo.mock.calls[0][0];
+    expect(logMessage).toContain("SAVING session");
+  });
+
+  it("Should not log session info on save when flag is off", async () => {
+    mockActiveFeature.mockReturnValue(false);
+    const session = Session.newInstance();
+
+    await saveSession(session);
+
+    expect(mockLoggerInfo).not.toHaveBeenCalled();
+  });
+
+  it("Should call getData on redisStore", async () => {
+    const session: Session = await loadSession(COOKIE_ID);
+
+    expect(mockRedisStoreGetData).toHaveBeenCalledTimes(1);
+    expect(mockRedisStoreGetData.mock.calls[0][0]).toEqual(session.sessionKey());
+  });
+
+  it("Should log session info on load when flag is on", async () => {
+    mockActiveFeature.mockReturnValue(true);
+
+    await loadSession(COOKIE_ID);
+
+    const logMessage1 = mockLoggerInfo.mock.calls[0][0];
+    expect(logMessage1).toContain("LOADING session");
+
+    const logMessage2 = mockLoggerInfo.mock.calls[1][0];
+    expect(logMessage2).toContain("LOADED session")
+  });
+
+  it("Should not log session info on load when flag is off", async () => {
+    mockActiveFeature.mockReturnValue(false);
+
+    await loadSession(COOKIE_ID);
+
+    expect(mockLoggerInfo).not.toHaveBeenCalled();
+  });
+
+  it("Should hide access tokens from log", async () => {
+    mockActiveFeature.mockReturnValue(true);
+    const session = Session.newInstance();
+    session.data = {
+        signin_info: {
+            access_token: {
+                access_token: "ABCDE",
+                refresh_token: "FGHIJ"
+            }
+        }
+    }
+
+    await saveSession(session);
+
+    const logMessage = mockLoggerInfo.mock.calls[0][0];
+    expect(logMessage).toContain("*** HIDDEN ***");
+    expect(logMessage).not.toContain("ABCDE");
+    expect(logMessage).not.toContain("FGHIJ");
+  });
+});


### PR DESCRIPTION
To help diagnose a live issue we would like to log out the session signin_info data and hide the access tokens f they are present.
We want to log this info out at the point where Redis is used to save and load data.