### PR TITLE
ASM-473 Exclude healthcheck from session and csrf middleware

### DIFF
--- a/src/test/controllers/healthcheck.controller.spec.unit.ts
+++ b/src/test/controllers/healthcheck.controller.spec.unit.ts
@@ -1,10 +1,14 @@
 jest.mock("../../services/redis.service");
+jest.mock("../../session/middleware");
 
 import * as request from "supertest";
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";
 import {EXTENSIONS_HEALTHCHECK} from "../../model/page.urls";
+import sessionMiddleware from "../../session/middleware";
+
+const mockCustomExtensionsSessionMiddleware = sessionMiddleware as jest.Mock;
 
 describe("HEALTHCHECK controller", () => {
 
@@ -19,4 +23,11 @@ describe("HEALTHCHECK controller", () => {
     expect(response.status).toEqual(200);
     expect(response.text).toContain("OK");
   });
+
+  test("Should not run csrf or session middleware", async () => {
+    await request(app).get(EXTENSIONS_HEALTHCHECK);
+    expect(mockMiddlewares.mockCsrfProtectionMiddleware).not.toHaveBeenCalled();
+    expect(mockMiddlewares.mockSessionMiddleware).not.toHaveBeenCalled();
+    expect(mockCustomExtensionsSessionMiddleware).not.toHaveBeenCalled();
+  })
 });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ASM-473

Prevent the healthcheck call executing the session and csrf middleware functions