### PR TITLE
ASM-2126 Fix the Jest warnings in tests

### DIFF
--- a/src/test/authentication/middleware/index.spec.unit.ts
+++ b/src/test/authentication/middleware/index.spec.unit.ts
@@ -11,7 +11,7 @@ jest.mock("redis", () => {
 });
 jest.mock("../../../services/redis.service");
 
-import * as request from 'supertest';
+import request = require("supertest");
 import app from '../../../app';
 import {COOKIE_NAME} from "../../../session/config";
 import * as keys from "../../../session/keys"

--- a/src/test/availability/middleware/service.availability.spec.unit.ts
+++ b/src/test/availability/middleware/service.availability.spec.unit.ts
@@ -12,7 +12,7 @@ jest.mock("redis", () => {
 jest.mock("../../../services/redis.service");
 
 import app from '../../../app';
-import * as request from 'supertest';
+import request = require("supertest");
 import {COOKIE_NAME} from "../../../session/config";
 
 const UNAVAILABLE_TEXT = "service is unavailable";

--- a/src/test/controllers/accounts/accounts.date.controller.spec.unit.ts
+++ b/src/test/controllers/accounts/accounts.date.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../../services/redis.service");
 jest.mock("../../../services/reason.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../../mock.middleware";
 import app from "../../../app";

--- a/src/test/controllers/accounts/accounts.information.controller.spec.unit.ts
+++ b/src/test/controllers/accounts/accounts.information.controller.spec.unit.ts
@@ -3,7 +3,8 @@ jest.mock("../../../services/reason.service");
 jest.mock("../../../services/session.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../../mock.middleware";
 import app from "../../../app";

--- a/src/test/controllers/add.extension.reason.controller.spec.unit.ts
+++ b/src/test/controllers/add.extension.reason.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../services/redis.service");
 jest.mock("../../services/reason.service");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/back.link.controller.spec.unit.ts
+++ b/src/test/controllers/back.link.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../services/redis.service");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/check.your.answers.controller.spec.unit.ts
+++ b/src/test/controllers/check.your.answers.controller.spec.unit.ts
@@ -2,7 +2,7 @@ jest.mock("../../client/apiclient");
 jest.mock("../../services/redis.service");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/choose.reason.controller.spec.unit.ts
+++ b/src/test/controllers/choose.reason.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../services/redis.service");
 jest.mock("../../client/apiclient");
 jest.mock("../../services/reason.service");
 
-import * as superTest from "supertest";
+
+import superTest = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/company.details.controller.spec.unit.ts
+++ b/src/test/controllers/company.details.controller.spec.unit.ts
@@ -4,7 +4,8 @@ jest.mock("../../services/redis.service");
 jest.mock("../../services/session.service");
 jest.mock("../../logger");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import {

--- a/src/test/controllers/company.number.controller.spec.unit.ts
+++ b/src/test/controllers/company.number.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../services/redis.service");
 jest.mock("../../client/api.enumerations");
 jest.mock("../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/confirmation.controller.spec.unit.ts
+++ b/src/test/controllers/confirmation.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../services/redis.service");
 jest.mock("../../client/apiclient");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/document.option.controller.spec.unit.ts
+++ b/src/test/controllers/document.option.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../services/redis.service");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/document.upload.controller.spec.unit.ts
+++ b/src/test/controllers/document.upload.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../services/redis.service");
 jest.mock("../../client/apiclient");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 import * as fs from "fs";
 import * as path from "path";
 

--- a/src/test/controllers/download.attachment.controller.spec.unit.ts
+++ b/src/test/controllers/download.attachment.controller.spec.unit.ts
@@ -15,7 +15,8 @@ jest.mock("../../client/apiclient", () => {
 });
 
 import {NextFunction, Request, Response} from "express";
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/download.attachment.landing.controller.spec.unit.ts
+++ b/src/test/controllers/download.attachment.landing.controller.spec.unit.ts
@@ -7,7 +7,8 @@ jest.mock("../../authentication/middleware/download", () => {
   }
 });
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/error.controller.csrf.spec.unit.ts
+++ b/src/test/controllers/error.controller.csrf.spec.unit.ts
@@ -14,7 +14,8 @@ jest.mock("../../client/apiclient");
 
 import { CsrfError } from "@companieshouse/web-security-node";
 import {NextFunction, Request, Response} from "express";
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import app from "../../app";
 import * as pageURLs from "../../model/page.urls";

--- a/src/test/controllers/error.controller.spec.unit.ts
+++ b/src/test/controllers/error.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../services/redis.service");
 
 import {NextFunction, Request, Response} from "express";
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/extension.limit.reached.spec.unit.ts
+++ b/src/test/controllers/extension.limit.reached.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../client/apiclient");
 jest.mock("../../services/redis.service");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/healthcheck.controller.spec.unit.ts
+++ b/src/test/controllers/healthcheck.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../services/redis.service");
 jest.mock("../../session/middleware");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/illness/continued.illness.controller.spec.unit.ts
+++ b/src/test/controllers/illness/continued.illness.controller.spec.unit.ts
@@ -3,7 +3,8 @@ jest.mock("../../../services/reason.service");
 jest.mock("../../../services/session.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../../mock.middleware";
 import app from "../../../app";

--- a/src/test/controllers/illness/illness.end.date.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.end.date.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../../services/redis.service");
 jest.mock("../../../client/apiclient");
 jest.mock("../../../services/reason.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 import * as moment from "moment";
 
 import mockMiddlewares from "../../mock.middleware";

--- a/src/test/controllers/illness/illness.information.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.information.controller.spec.unit.ts
@@ -3,7 +3,7 @@ jest.mock("../../../services/reason.service");
 jest.mock("../../../services/session.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+import request = require("supertest");
 
 import mockMiddlewares from "../../mock.middleware";
 import app from "../../../app";

--- a/src/test/controllers/illness/illness.start.date.controller.spec.unit.ts
+++ b/src/test/controllers/illness/illness.start.date.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../../services/redis.service");
 jest.mock("../../../services/reason.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 import * as moment from "moment";
 
 import mockMiddlewares from "../../mock.middleware";

--- a/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
+++ b/src/test/controllers/illness/who.was.ill.controller.spec.unit.ts
@@ -3,7 +3,8 @@ jest.mock("../../../services/reason.service");
 jest.mock("../../../services/session.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../../mock.middleware";
 import app from "../../../app";

--- a/src/test/controllers/other/reason.other.controller.spec.unit.ts
+++ b/src/test/controllers/other/reason.other.controller.spec.unit.ts
@@ -3,7 +3,8 @@ jest.mock("../../../services/reason.service");
 jest.mock("../../../services/session.service");
 jest.mock("../../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../../mock.middleware";
 import app from "../../../app";

--- a/src/test/controllers/print.application.controller.spec.unit.ts
+++ b/src/test/controllers/print.application.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../client/apiclient");
 jest.mock("../../services/redis.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/remove.document.controller.spec.unit.ts
+++ b/src/test/controllers/remove.document.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../client/apiclient");
 jest.mock("../../services/redis.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/remove.reason.controller.spec.unit.ts
+++ b/src/test/controllers/remove.reason.controller.spec.unit.ts
@@ -1,7 +1,8 @@
 jest.mock("../../services/redis.service");
 jest.mock("../../client/apiclient");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/controllers/too.soon.controller.spec.unit.ts
+++ b/src/test/controllers/too.soon.controller.spec.unit.ts
@@ -2,7 +2,8 @@ jest.mock("../../client/apiclient");
 jest.mock("../../services/redis.service");
 jest.mock("../../services/session.service");
 
-import * as request from "supertest";
+
+import request = require("supertest");
 
 import mockMiddlewares from "../mock.middleware";
 import app from "../../app";

--- a/src/test/routes/index.spec.unit.ts
+++ b/src/test/routes/index.spec.unit.ts
@@ -12,7 +12,7 @@ jest.mock("redis", () => {
 jest.mock("../../services/redis.service");
 
 import app from '../../app';
-import * as request from 'supertest';
+import request = require("supertest");
 import {COOKIE_NAME} from "../../session/config";
 import {loadSession} from "../../services/redis.service";
 import {loadMockSession} from "../mock.utils";

--- a/src/test/session/middleware/history.spec.unit.ts
+++ b/src/test/session/middleware/history.spec.unit.ts
@@ -14,7 +14,8 @@ jest.mock("../../../services/session.service");
 jest.mock("../../../client/apiclient");
 
 import app from "../../../app";
-import * as request from "supertest";
+
+import request = require("supertest");
 import Session from "../../../session/session";
 import * as keys from "../../../session/keys";
 import * as pageURLs from "../../../model/page.urls";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "pretty": true,
     "sourceMap": true,
     "target": "es6",
+    "types": ["jest"],
     "outDir": "./dist",
     "baseUrl": "./src",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ASM-2126

Fix the Jest warning in the tests
Had to go with require("supertest"); approach, otherwise we have to fix all the imports in all the files (as per the previous large PR)


This pull request standardizes the way the `supertest` library is imported across all unit test files. The import style is changed from ES module syntax (`import * as request from "supertest"`) to CommonJS-style (`import request = require("supertest")`). This improves consistency and may help with compatibility in TypeScript or certain test environments.

**Test import style standardization:**

* Updated all instances of `import * as request from "supertest"` to `import request = require("supertest")` in test files such as `accounts.date.controller.spec.unit.ts`, `accounts.information.controller.spec.unit.ts`, `add.extension.reason.controller.spec.unit.ts`, `back.link.controller.spec.unit.ts`, `check.your.answers.controller.spec.unit.ts`, `choose.reason.controller.spec.unit.ts`, `company.details.controller.spec.unit.ts`, `company.number.controller.spec.unit.ts`, `confirmation.controller.spec.unit.ts`, `document.option.controller.spec.unit.ts`, `document.upload.controller.spec.unit.ts`, `download.attachment.controller.spec.unit.ts`, `download.attachment.landing.controller.spec.unit.ts`, `error.controller.csrf.spec.unit.ts`, `error.controller.spec.unit.ts`, `extension.limit.reached.spec.unit.ts`, `healthcheck.controller.spec.unit.ts`, `continued.illness.controller.spec.unit.ts`, `index.spec.unit.ts`, and `service.availability.spec.unit.ts`. [[1]](diffhunk://#diff-5d855fad50100ff7de879ae605639b9346eec3a0c580f6ab1c6904819292ff70L5-R6) [[2]](diffhunk://#diff-f07135639d8cb48cff6957f065c1bb889c9b9e8cc40f6342d327d4a90f21807eL6-R7) [[3]](diffhunk://#diff-86a7f862967aa4a1f6866f79176a41e2c95bb47b10537cee343f6024ddc8fbecL5-R6) [[4]](diffhunk://#diff-d5eaa349aee6f344da90c565e1bf8350ca28e891c071757f6448e2e5bdf4c0efL4-R5) [[5]](diffhunk://#diff-eea636d935437b7bfda939f1dce0b950fdb88f4eb1dae983be4d3cc73daace40L5-R5) [[6]](diffhunk://#diff-a4e6487193c3ae1c377a83332347ddd64a27675e1f5b3622910ba5321e7bad95L5-R6) [[7]](diffhunk://#diff-0e0d477f39f3c9ea24fca21713d421db10868a40d9f1cf83ae0e307ed4daddb3L7-R8) [[8]](diffhunk://#diff-14c7dc4b5ce803ba6bf6453a7bafc2fd82eb1b664ecc7432af1441871e96b432L5-R6) [[9]](diffhunk://#diff-5d265169d6080c2bb08ded8dada2818b9417cd38af1f05c3acb9cdd87fe32170L5-R6) [[10]](diffhunk://#diff-dd02894e82d50f0cefbdc2d22d4be263d8a5aa83c81df85fd3e1f2167f3c754aL4-R5) [[11]](diffhunk://#diff-dea7874f128a48c084965db9079126505c0dc0aa139fde89ae6be9cd3b37c5d8L5-R6) [[12]](diffhunk://#diff-6a975f4af9779f02f1081bff7fa27549ea3ae7f8aae70a03db74b6df8ca8b284L18-R19) [[13]](diffhunk://#diff-61b2e266db4fbdc0a1239ba94e190e0754861dd3b3954c55c08283782021a928L10-R11) [[14]](diffhunk://#diff-ea1bd465fb549669e6be6b1c7957dcb338d92364826c8f95647de3f123ecb185L17-R18) [[15]](diffhunk://#diff-169e2d0972741b92c4f461d339764310f7681b89e363978f2d958466c4630123L4-R5) [[16]](diffhunk://#diff-f17e7ea9254a627c73df224feeff4a288fca645edbb08db38e3ab6c20298c07aL5-R6) [[17]](diffhunk://#diff-39ca5cb7f9a26074be9311812175f7074e50b62a2fcb93a3403b6a692c311410L4-R5) [[18]](diffhunk://#diff-ae917b88eeead344376460c902815aa4624d8cf3779f675c8b4878e69b04f722L6-R7) [[19]](diffhunk://#diff-661dcef66cb971bd8911ff47b22bd75821927425c7f715109c0ee256b9ef185fL14-R14) [[20]](diffhunk://#diff-6c81811564f9505a4f88bfc05a69772f447e645e4dfd453205ffc51dcc92932aL15-R15)